### PR TITLE
Adds non-null check to onActivityResult

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -459,7 +459,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 mEmailInput.getEditText().postDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        if (isAdded() && mEmailInput != null) {
+                        if (isAdded()) {
                             ActivityUtils.showKeyboard(mEmailInput.getEditText());
                         }
                     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -459,7 +459,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 mEmailInput.getEditText().postDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        if (isAdded()) {
+                        if (isAdded() && mEmailInput != null) {
                             ActivityUtils.showKeyboard(mEmailInput.getEditText());
                         }
                     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
@@ -317,6 +317,10 @@ public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> im
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == EMAIL_CREDENTIALS_REQUEST_CODE) {
+            if (mEmailInput == null) {
+                // Activity result received before the fragments onCreateView(), disregard result.
+                return;
+            }
             if (resultCode == RESULT_OK) {
                 Credential credential = data.getParcelableExtra(Credential.EXTRA_KEY);
                 mEmailInput.getEditText().setText(credential.getId());


### PR DESCRIPTION
Fixes - https://github.com/wordpress-mobile/WordPress-Android/issues/7362
I'm pretty sure this NPE happens when the view gets destroyed right after `onActivityResult` happens. I'm adding a non-null check in the `postDelayed` method so we don't show a keyboard if the view is already gone. I know that the `isAdded` check is there for the same reason but it seems to not work correctly.