### PR TITLE
issue/glide-4.9 

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -57,8 +57,8 @@ dependencies {
         }
     }
 
-    implementation 'com.github.bumptech.glide:glide:4.6.1'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.6.1'
+    implementation 'com.github.bumptech.glide:glide:4.9.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
 
     // Dagger
     implementation 'com.google.dagger:dagger:2.11'


### PR DESCRIPTION
This PR updates the Glide library to v4.9.0, which is a necessary step prior to our AndroidX migration. A similar change needs to be made to [WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/issues/9875) and [WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/1067).