### PR TITLE
Add redirect url support to gotConnectedSiteInfo

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -48,7 +48,7 @@ public interface LoginListener {
     // Login Site Address input callbacks
     void alreadyLoggedInWpcom(ArrayList<Integer> oldSitesIds);
     void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl);
-    void gotConnectedSiteInfo(String siteAddress, boolean hasJetpack);
+    void gotConnectedSiteInfo(@NonNull String siteAddress, @Nullable String redirectUrl, boolean hasJetpack);
     void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress);
     void handleSslCertificateError(MemorizingTrustManager memorizingTrustManager, SelfSignedSSLCallback callback);
     void helpSiteAddress(String url);

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -425,7 +425,10 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
                 } else if (event.info.hasJetpack && event.info.isJetpackActive && event.info.isJetpackConnected) {
                     hasJetpack = true;
                 }
-                mLoginListener.gotConnectedSiteInfo(event.info.url, hasJetpack);
+                mLoginListener.gotConnectedSiteInfo(
+                        event.info.url,
+                        event.info.urlAfterRedirects,
+                        hasJetpack);
             }
         }
     }


### PR DESCRIPTION
This PR merges the changes in this WCAndroid PR: https://github.com/woocommerce/woocommerce-android/pull/1224 to support passing the `redirectUrl` back to the `LoginListener`. See the original PR for more information. 

## To Test
I've created a new branch in WPAndroid that includes the changes in this branch, along with any tweaks necessary to support these changes: `amanda/login-lib-redirect-support`, and opened a draft PR for testing those changes: https://github.com/wordpress-mobile/WordPress-Android/pull/10232