### PR TITLE
Merge from WPAndroid: Sign up logged-in analytics

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -500,7 +500,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
 
     @Override
     protected void onLoginFinished() {
-        mAnalyticsListener.trackAnalyticsSignIn(mAccountStore, mSiteStore, true);
+        mAnalyticsListener.trackAnalyticsSignIn(true);
 
         mLoginListener.startPostLoginServices();
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -1,12 +1,9 @@
 package org.wordpress.android.login;
 
-import org.wordpress.android.fluxc.store.AccountStore;
-import org.wordpress.android.fluxc.store.SiteStore;
-
 import java.util.Map;
 
 public interface LoginAnalyticsListener {
-    void trackAnalyticsSignIn(AccountStore accountStore, SiteStore siteStore, boolean isWpcomLogin);
+    void trackAnalyticsSignIn(boolean isWpcomLogin);
     void trackCreatedAccount(String username, String email);
     void trackEmailFormViewed();
     void trackInsertedInvalidUrl();

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -443,7 +443,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
 
     @Override
     protected void onLoginFinished() {
-        mAnalyticsListener.trackAnalyticsSignIn(mAccountStore, mSiteStore, true);
+        mAnalyticsListener.trackAnalyticsSignIn(true);
         mLoginListener.loggedInViaSocialAccount(mOldSitesIDs, false);
     }
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -253,7 +253,7 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
 
     @Override
     protected void onLoginFinished() {
-        mAnalyticsListener.trackAnalyticsSignIn(mAccountStore, mSiteStore, true);
+        mAnalyticsListener.trackAnalyticsSignIn(true);
         mLoginListener.startPostLoginServices();
 
         if (mIsSocialLogin) {

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -445,7 +445,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
     @Override
     protected void onLoginFinished() {
-        mAnalyticsListener.trackAnalyticsSignIn(mAccountStore, mSiteStore, mIsWpcom);
+        mAnalyticsListener.trackAnalyticsSignIn(mIsWpcom);
 
         mLoginListener.startPostLoginServices();
 
@@ -453,7 +453,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
     }
 
     private void finishLogin() {
-        mAnalyticsListener.trackAnalyticsSignIn(mAccountStore, mSiteStore, mIsWpcom);
+        mAnalyticsListener.trackAnalyticsSignIn(mIsWpcom);
 
         // mark as finished so any subsequent onSiteChanged (e.g. triggered by WPMainActivity) won't be intercepted
         mLoginFinished = true;

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
@@ -203,6 +203,7 @@ public class SignupGoogleFragment extends GoogleFragment {
             AppLog.d(T.MAIN,
                     "GOOGLE SIGNUP: onAuthenticationChanged - new wordpress account created");
             mAnalyticsListener.trackCreatedAccount(event.userName, mGoogleEmail);
+            mAnalyticsListener.trackAnalyticsSignIn(true);
             mGoogleListener.onGoogleSignupFinished(mDisplayName, mGoogleEmail, mPhotoUrl, event.userName);
             // Continue with login since existing account was selected.
         } else {


### PR DESCRIPTION
This pulls in the latest changes to the login library in WPAndroid, which aside from some merge commits is made up of this PR:

https://github.com/wordpress-mobile/WordPress-Android/pull/10280

~Leaving this is a draft until I make a counterpart PR pulling this into WCAndroid, as this is a breaking change (`LoginAnalyticsListener` has been modified). Will take care of that tomorrow.~