### PR TITLE
Merge from WPAndroid: Gradle 5.4.1 upgrade

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.27.0'
     testImplementation 'androidx.arch.core:core-testing:2.0.1'
-    testImplementation 'org.robolectric:robolectric:3.6.1'
+    testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'org.assertj:assertj-core:3.11.1'
 }
 

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.1'
     }
 }
 
@@ -32,7 +32,7 @@ android {
 
 dependencies {
     implementation ('org.wordpress:utils:1.20.3') {
-        exclude group: "com.mcxiaoke.volley"
+        exclude group: "com.android.volley"
     }
 
     implementation 'androidx.appcompat:appcompat:1.0.2'

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -51,7 +51,7 @@ dependencies {
             exclude group: "org.wordpress", module: "utils"
         }
     } else {
-        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:9f07b031646dd3e6021d4b8e0a35647c9109ff27") {
+        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.5.1-beta-2") {
             exclude group: "com.android.support"
             exclude group: "org.wordpress", module: "utils"
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 24 12:48:58 EDT 2017
+#Fri Oct 18 14:55:25 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
This PR reflects the changes made to login library in https://github.com/wordpress-mobile/WordPress-Android/pull/10583/ for the Gradle 5.4.1 upgrade. I didn't have the original branch anymore, so I pushed these changes from `develop` but luckily there are no other changes than the ones I made here: https://github.com/wordpress-mobile/WordPress-Android/pull/10583/files#diff-6c0e3fe2287f469b5c719abb847d7992