### PR TITLE
Add signup flow name parameter to /auth/send-signup-email request

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -51,7 +51,7 @@ dependencies {
             exclude group: "org.wordpress", module: "utils"
         }
     } else {
-        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.5.1-beta-2") {
+        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.5.1-beta-4") {
             exclude group: "com.android.support"
             exclude group: "org.wordpress", module: "utils"
         }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
@@ -40,6 +40,7 @@ public class SignupMagicLinkFragment extends Fragment {
     private static final String ARG_EMAIL_ADDRESS = "ARG_EMAIL_ADDRESS";
     private static final String ARG_IS_JETPACK_CONNECT = "ARG_IS_JETPACK_CONNECT";
     private static final String ARG_JETPACK_CONNECT_SOURCE = "ARG_JETPACK_CONNECT_SOURCE";
+    private static final String SIGNUP_FLOW_NAME = "mobile-android";
 
     public static final String TAG = "signup_magic_link_fragment_tag";
 
@@ -198,6 +199,7 @@ public class SignupMagicLinkFragment extends Fragment {
             AuthEmailPayloadSource source = getAuthEmailPayloadSource();
             AuthEmailPayload authEmailPayload = new AuthEmailPayload(mEmail, true,
                     mIsJetpackConnect ? AuthEmailPayloadFlow.JETPACK : null, source);
+            authEmailPayload.signupFlowName = SIGNUP_FLOW_NAME;
             mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(authEmailPayload));
         }
     }


### PR DESCRIPTION
This PR applies the changes for `/auth/send-signup-email` request in WPAndroid repo: https://github.com/wordpress-mobile/WordPress-Android/pull/10627. Please see the original PR for details.

It also updates the default FluxC hash to the latest since `signupFlowName` property is only recently added to `AuthEmailPayload`: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1406