### PR TITLE
Accessibility : Sign Up - Terms of Service Announcement Fix

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -57,8 +57,8 @@ dependencies {
         }
     }
 
-    implementation 'com.github.bumptech.glide:glide:4.9.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.10.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
 
     // Dagger
     implementation 'com.google.dagger:dagger:2.22.1'

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -256,7 +256,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         super.onSaveInstanceState(outState);
 
         outState.putBoolean(KEY_LOGIN_FINISHED, mLoginFinished);
-        outState.putBoolean(KEY_LOGIN_FINISHED, mLoginStarted);
+        outState.putBoolean(KEY_LOGIN_STARTED, mLoginStarted);
         outState.putString(KEY_REQUESTED_USERNAME, mRequestedUsername);
         outState.putString(KEY_REQUESTED_PASSWORD, mRequestedPassword);
         outState.putIntegerArrayList(KEY_OLD_SITES_IDS, mOldSitesIDs);

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -52,6 +52,7 @@ import dagger.android.support.AndroidSupportInjection;
 public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginListener> implements TextWatcher,
         OnEditorCommitListener {
     private static final String KEY_LOGIN_FINISHED = "KEY_LOGIN_FINISHED";
+    private static final String KEY_LOGIN_STARTED = "KEY_LOGIN_STARTED";
     private static final String KEY_REQUESTED_USERNAME = "KEY_REQUESTED_USERNAME";
     private static final String KEY_REQUESTED_PASSWORD = "KEY_REQUESTED_PASSWORD";
     private static final String KEY_OLD_SITES_IDS = "KEY_OLD_SITES_IDS";
@@ -74,6 +75,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
     private boolean mAuthFailed;
     private boolean mLoginFinished;
+    private boolean mLoginStarted;
 
     private String mRequestedUsername;
     private String mRequestedPassword;
@@ -229,6 +231,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
         if (savedInstanceState != null) {
             mLoginFinished = savedInstanceState.getBoolean(KEY_LOGIN_FINISHED);
+            mLoginStarted = savedInstanceState.getBoolean(KEY_LOGIN_STARTED);
 
             mRequestedUsername = savedInstanceState.getString(KEY_REQUESTED_USERNAME);
             mRequestedPassword = savedInstanceState.getString(KEY_REQUESTED_PASSWORD);
@@ -253,6 +256,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         super.onSaveInstanceState(outState);
 
         outState.putBoolean(KEY_LOGIN_FINISHED, mLoginFinished);
+        outState.putBoolean(KEY_LOGIN_FINISHED, mLoginStarted);
         outState.putString(KEY_REQUESTED_USERNAME, mRequestedUsername);
         outState.putString(KEY_REQUESTED_PASSWORD, mRequestedPassword);
         outState.putIntegerArrayList(KEY_OLD_SITES_IDS, mOldSitesIDs);
@@ -277,6 +281,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
             return;
         }
 
+        mLoginStarted = true;
         startProgress();
 
         mRequestedUsername = getCleanedUsername();
@@ -418,6 +423,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         }
 
         if (event.isError()) {
+            mLoginStarted = false;
             if (mRequestedUsername == null) {
                 // just bail since the operation was cancelled
                 return;
@@ -472,11 +478,12 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
-        if (!isAdded() || mLoginFinished) {
+        if (!isAdded() || mLoginFinished || !mLoginStarted) {
             return;
         }
 
         if (event.isError()) {
+            mLoginStarted = false;
             if (mRequestedUsername == null) {
                 // just bail since the operation was cancelled
                 return;

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupBottomSheetDialog.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupBottomSheetDialog.java
@@ -54,6 +54,7 @@ public class SignupBottomSheetDialog extends WPBottomSheetDialog {
         });
 
         setContentView(layout);
+        setTitle(R.string.signup_title);
 
         // Set peek height to full height of view to avoid signup buttons being off screen when
         // bottom sheet is shown with small screen height (e.g. landscape orientation).

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
@@ -40,6 +40,7 @@ public class SignupMagicLinkFragment extends Fragment {
     private static final String ARG_EMAIL_ADDRESS = "ARG_EMAIL_ADDRESS";
     private static final String ARG_IS_JETPACK_CONNECT = "ARG_IS_JETPACK_CONNECT";
     private static final String ARG_JETPACK_CONNECT_SOURCE = "ARG_JETPACK_CONNECT_SOURCE";
+    private static final String SIGNUP_FLOW_NAME = "mobile-android";
 
     public static final String TAG = "signup_magic_link_fragment_tag";
 
@@ -198,6 +199,7 @@ public class SignupMagicLinkFragment extends Fragment {
             AuthEmailPayloadSource source = getAuthEmailPayloadSource();
             AuthEmailPayload authEmailPayload = new AuthEmailPayload(mEmail, true,
                     mIsJetpackConnect ? AuthEmailPayloadFlow.JETPACK : null, source);
+            authEmailPayload.signupFlowName = SIGNUP_FLOW_NAME;
             mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(authEmailPayload));
         }
     }

--- a/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="signup_magic_link_error_button_positive">Retry</string>
     <string name="signup_magic_link_message">We sent you a magic signup link! Check your email on this device, and tap the link in the email to finish signing up.</string>
     <string name="signup_magic_link_progress">Sending email</string>
+    <string name="signup_title">Sign up for WordPress</string>
     <string name="signup_terms_of_service_text">By signing up, you agree to our %1$sTerms of Service%2$s.</string>
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>


### PR DESCRIPTION
Fixes [#10510](https://github.com/wordpress-mobile/WordPress-Android/issues/10510)

To test:
[Use this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/11073)

1. Go to Settings > Accessibility > TalkBack and turn on "Use service".
2. In the WordPress app, go to the log in screen.
3. Double tap the "Sign up for WordPress.com" button.
4. You will hear "Sign Up For WordPress" as the first announcement. 

This fix solves the issue partially because when the device goes to sleep and wakes up it still does the announcement of the terms of service text twice. Nonetheless, we have stopped the initial double announcement so it's worth merging this in until another solution is found. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

