### PR TITLE
Using getViewLifecycleOwner() for observers

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -141,12 +141,12 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
         mLoginSiteAddressValidator = new LoginSiteAddressValidator();
 
-        mLoginSiteAddressValidator.getIsValid().observe(this, new Observer<Boolean>() {
+        mLoginSiteAddressValidator.getIsValid().observe(getViewLifecycleOwner(), new Observer<Boolean>() {
             @Override public void onChanged(Boolean enabled) {
                 getPrimaryButton().setEnabled(enabled);
             }
         });
-        mLoginSiteAddressValidator.getErrorMessageResId().observe(this, new Observer<Integer>() {
+        mLoginSiteAddressValidator.getErrorMessageResId().observe(getViewLifecycleOwner(), new Observer<Integer>() {
             @Override public void onChanged(Integer resId) {
                 if (resId != null) {
                     showError(resId);


### PR DESCRIPTION
Related to changes in https://github.com/wordpress-mobile/WordPress-Android/pull/11934

This PR only makes sure to pass the lifecycleOwner to the observer instead of the Fragment, which can have a different lifecycle as explained there.

