### PR TITLE
Fix password drawable on login screen

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
@@ -79,8 +79,8 @@ public class WPLoginInputRow extends RelativeLayout {
                     mEditText.setHintTextColor(getResources().getColor(android.R.color.transparent));
                 }
                 if (a.hasValue(R.styleable.wpLoginInputRow_passwordToggleEnabled)) {
-                    mTextInputLayout.setPasswordVisibilityToggleEnabled(
-                            a.getBoolean(R.styleable.wpLoginInputRow_passwordToggleEnabled, false));
+                    mTextInputLayout.setEndIconMode(TextInputLayout.END_ICON_PASSWORD_TOGGLE);
+                    mTextInputLayout.setEndIconDrawable(R.drawable.selector_password_visibility);
                 }
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {


### PR DESCRIPTION
Follow up WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/12000

Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/9905

To test: Open login screen with a device that has xhdpi resolution and there should be a good password icon (eye) and not WordPress logo icon 