### PR TITLE
Merge WCAndroid updates

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         kotlin_version = '1.3.61'
         kotlin_ktx_version = '1.2.0'
-        daggerVersion = '2.22.1'
+        daggerVersion = '2.29.1'
         appCompatVersion = '1.0.2'
     }
     repositories {

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -573,10 +573,13 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
 
     @Override
     protected void buildToolbar(Toolbar toolbar, ActionBar actionBar) {
+        if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
+            actionBar.setTitle(R.string.log_in);
+            return;
+        }
+
         if (mShouldUseNewLayout) {
             actionBar.setTitle(R.string.get_started);
-        } else if (mOptionalSiteCredsLayout) {
-            actionBar.setTitle(R.string.log_in);
         } else {
             super.buildToolbar(toolbar, actionBar);
         }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -193,14 +193,16 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 if (!mShouldUseNewLayout) {
                     label.setText(R.string.enter_email_wordpress_com);
                 } else if (!TextUtils.isEmpty(mLoginSiteUrl)) {
-                    label.setText(getString(R.string.enter_email_for_site, mLoginSiteUrl));
+                    label.setText(Html.fromHtml(
+                            getString(R.string.enter_email_for_site, mLoginSiteUrl)));
                 } else {
                     label.setText(R.string.enter_email_to_continue_wordpress_com);
                 }
                 break;
             case WOO_LOGIN_MODE:
                 if (mOptionalSiteCredsLayout) {
-                    label.setText(getString(R.string.enter_email_for_site, mLoginSiteUrl));
+                    label.setText(Html.fromHtml(
+                            getString(R.string.enter_email_for_site, mLoginSiteUrl)));
                 } else {
                     label.setText(getString(R.string.enter_email_wordpress_com));
                 }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 
 import java.util.ArrayList;
 
@@ -59,6 +60,7 @@ public interface LoginListener {
     void handleSslCertificateError(MemorizingTrustManager memorizingTrustManager, SelfSignedSSLCallback callback);
     void helpSiteAddress(String url);
     void helpFindingSiteAddress(String username, SiteStore siteStore);
+    void handleSiteAddressError(ConnectSiteInfoPayload siteInfo);
 
     // Login username password callbacks
     void saveCredentialsInSmartLock(@Nullable String username, @Nullable String password,

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -224,7 +224,10 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
     @Override
     public void afterTextChanged(Editable s) {
-        mLoginSiteAddressValidator.setAddress(EditTextUtils.getText(mSiteAddressInput.getEditText()));
+        if (mSiteAddressInput != null) {
+            mLoginSiteAddressValidator
+                    .setAddress(EditTextUtils.getText(mSiteAddressInput.getEditText()));
+        }
     }
 
     @Override
@@ -233,7 +236,9 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
-        mSiteAddressInput.setError(null);
+        if (mSiteAddressInput != null) {
+            mSiteAddressInput.setError(null);
+        }
     }
 
     private void showError(int messageId) {

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -398,7 +398,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
             showError(R.string.invalid_site_url_message);
         } else if (!siteInfo.isWordPress) {
             // Not a WordPress site
-            showError(R.string.enter_wordpress_site);
+            mLoginListener.handleSiteAddressError(siteInfo);
         } else {
             mLoginListener.gotConnectedSiteInfo(
                     siteInfo.url,

--- a/WordPressLoginFlow/src/main/res/layout/login_email_optional_site_creds_screen.xml
+++ b/WordPressLoginFlow/src/main/res/layout/login_email_optional_site_creds_screen.xml
@@ -78,7 +78,8 @@
             app:iconGravity="textStart"
             app:iconPadding="@dimen/margin_small_medium"
             app:iconSize="14dp"
-            app:iconTint="@null"
+            app:iconTint="@color/login_secondary_button_icon_tint_color"
+            app:iconTintMode="src_in"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />

--- a/WordPressLoginFlow/src/main/res/values/colors.xml
+++ b/WordPressLoginFlow/src/main/res/values/colors.xml
@@ -121,6 +121,7 @@
     <color name="login_primary_button_normal_color">@color/blue_medium</color>
     <color name="login_primary_button_text_color">@color/white</color>
     <color name="login_secondary_button_text_color">@color/blue_wordpress</color>
+    <color name="login_secondary_button_icon_tint_color">@color/gray</color>
     <color name="login_google_button_text_color">@color/blue_wordpress</color>
     <color name="login_text_label_text_color">@color/grey_dark</color>
     <color name="login_input_label_static_text_color">@color/grey_text_min</color>

--- a/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -125,7 +125,6 @@
     <string name="login_discovery_error_ssl">We were unable to access your site because of a problem with the &lt;b>SSL Certificate&lt;/b>. You will need to reach out to your host to resolve this.</string>
     <string name="login_discovery_error_generic">We were unable to access your site. You will need to reach out to your host to resolve this.</string>
     <string name="enter_wpcom_or_jetpack_site">Please enter a WordPress.com or Jetpack-connected self-hosted WordPress site</string>
-    <string name="enter_wordpress_site">The website at this address is not a WordPress site. For us to connect to it, the site must have WordPress installed.</string>
     <string name="error_generic_network">A network error occurred. Please check your connection and try again.</string>
 
     <string name="notification_login_title_success">Logged in!</string>


### PR DESCRIPTION
This PR includes changes from the following PRs on WCAndroid:

- [Small Fix for a NullPointerException crash.](https://github.com/woocommerce/woocommerce-android/pull/3203)
- [Add new login tint color for secondary button icon](https://github.com/woocommerce/woocommerce-android/pull/3235)
- [Update title on WordPress.com login flow email screen](https://github.com/woocommerce/woocommerce-android/pull/3238)
- [Bold Store Address](https://github.com/woocommerce/woocommerce-android/pull/3236)
- [Fix broken password reset button](https://github.com/woocommerce/woocommerce-android/pull/3363)
- [Not a WordPress Site error flow](https://github.com/woocommerce/woocommerce-android/pull/3331)

There is only one change that will require changes to WPAndroid and that's to implement this new method in `LoginListener`: `handleSiteAddressError(ConnectSiteInfoPayload siteInfo)`. In the code it's only used by Woo so it can be left blank. All other changes should only be Woo-facing. 