### PR TITLE
Update login / signup buttons copy

### DIFF
--- a/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -93,7 +93,7 @@
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
     <string name="signup_with_google_progress">Signing up with Google&#8230;</string>
-    <string name="continue_with_wpcom">Continue with WordPress.com</string>
+    <string name="continue_with_wpcom">Log in or sign up with WordPress.com</string>
     <string name="enter_your_site_address">Enter your site address</string>
 
     <string name="google_error_timeout">Google took too long to respond. You may need to wait until you have a stronger internet connection.</string>


### PR DESCRIPTION
Fixes [WordPress-Android#13879](https://github.com/wordpress-mobile/WordPress-Android/issues/13879)
Related [WordPress-Android#13951](https://github.com/wordpress-mobile/WordPress-Android/pull/13951)
Related [WordPressAuthenticator-iOS#572](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/572)

This PR updates the copy on the login/signup button from Continue to WordPress.com to Log in or sign up with WordPress.com.

ℹ️ For more info please follow up on the `Fixes` and `Relates` PRs.