### PR TITLE
Add FetchSitesPayload to newFetchSitesAction

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -65,7 +65,7 @@ dependencies {
             exclude group: "org.wordpress", module: "utils"
         }
     } else {
-        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.6.22") {
+        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.15.0-beta-1") {
             exclude group: "com.android.support"
             exclude group: "org.wordpress", module: "utils"
         }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -37,6 +37,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AccountErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.util.AppLog;
@@ -332,7 +333,7 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
             mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
         } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
             // The user's account settings have also been fetched and stored - now we can fetch the user's sites
-            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(new FetchSitesPayload()));
             mDispatcher.dispatch(AccountActionBuilder.newFetchSubscriptionsAction());
         }
     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnSocialChanged;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialPayload;
+import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.login.LoginWpcomService.LoginState;
@@ -375,7 +376,7 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
         } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
             setState(LoginStep.FETCHING_SITES);
             // The user's account settings have also been fetched and stored - now we can fetch the user's sites
-            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(new FetchSitesPayload()));
         }
     }
 


### PR DESCRIPTION
This PR adds an empty `FetchSitesPayload` to `newFetchSitesAction` in the Login library as part of the Jetpack app filters support to fetch sites API.

Related Issue:
wordpress-mobile/WordPress-Android#14299
Related PRs:
FluxC: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1936
WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/14397
WCAndroid: https://github.com/woocommerce/woocommerce-android/pull/3805

**Merge Instructions**

- Make sure https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1936 is merged to `FluxC` `develop` and tag is created for it.
- Update `FluxC` tag in `build.gradle` [here](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/blob/develop/WordPressLoginFlow/build.gradle#L68) in this PR.
- Make sure all checks are passed.
- Merge this PR with `develop`.