### PR TITLE
Publish to s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: wordpress-mobile/android@0.0.22
+  android: wordpress-mobile/android@1.0.21
 
 commands:
   copy-gradle-properties:
@@ -24,8 +24,8 @@ jobs:
           command: ./gradlew --stacktrace lint checkstyle
       - android/save-gradle-cache
       - android/save-lint-results
-  Build:
-    executor: 
+  Test:
+    executor:
       name: android/default
       api-version: "27"
     steps:
@@ -33,12 +33,33 @@ jobs:
       - copy-gradle-properties
       - android/restore-gradle-cache
       - run:
-          name: Build
-          command: ./gradlew --stacktrace assembleDebug assembleRelease
+          name: Test
+          command: ./gradlew --stacktrace test
+      - android/save-gradle-cache
+  Build and upload to S3:
+    executor:
+      name: android/default
+      api-version: "27"
+    steps:
+      - checkout
+      - copy-gradle-properties
+      - android/restore-gradle-cache
+      - android/publish-to-s3:
+          publish_gradle_task: :WordPressLoginFlow:publishLibraryToS3
       - android/save-gradle-cache
 
 workflows:
   WordPress-Login-Flow-Android:
     jobs:
       - Lint
-      - Build
+      - Test:
+          filters:
+            tags:
+              only: /.*/
+      - Build and upload to S3:
+          requires:
+            - Test
+          filters:
+            tags:
+              only: /.*/
+

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -36,8 +36,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 2
-        versionName "1.1"
 
         vectorDrawables.useSupportLibrary = true
     }

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -8,10 +8,12 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.automattic.android:publish-to-s3:0.4.0'
     }
 }
 
@@ -19,6 +21,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'com.automattic.android.publish-library-to-s3'
 
 repositories {
     mavenCentral()
@@ -111,3 +114,10 @@ android.buildTypes.all { buildType ->
         }
     }
 }
+
+s3PublishLibrary {
+    groupId "org.wordpress"
+    artifactId "login"
+    from "release"
+}
+


### PR DESCRIPTION
This PR adds support to publish the library artifacts to S3 through a CircleCI task. It follows the same implementation as [WordPress-Utils-Android](https://github.com/wordpress-mobile/wordpress-utils-android) by taking advantage of [shared tasks in our CircleCI orb](https://github.com/wordpress-mobile/circleci-orbs/blob/trunk/src/android/orb.yml#L207) and [publish to s3 Gradle Plugin](https://github.com/Automattic/publish-to-s3-gradle-plugin).

It also removes the `Build` task and adds a `Test` task to CircleCI. We don't need a separate build task since we'll be assembling the release artifacts before we publish it to S3.

The published artifact can be tested in https://github.com/wordpress-mobile/WordPress-Android/pull/14742 & https://github.com/woocommerce/woocommerce-android/pull/4108. Note that the client PRs are not ready to be merged as translations still need to be handled, but we can go ahead with reviewing and merging this PR in preparation.