### PR TITLE
Onboarding Improvements: Extract Or Layout

### DIFF
--- a/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
+++ b/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
@@ -77,34 +77,16 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
 
-        <FrameLayout
+        <include
             android:id="@+id/orLayout"
+            layout="@layout/login_or_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_small_medium"
             app:layout_constraintTop_toBottomOf="@+id/spacer"
             app:layout_constraintBottom_toTopOf="@+id/continue_with_google"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintVertical_bias="1.0">
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_gravity="center_vertical"
-                android:alpha="0.12"
-                android:background="?attr/colorOnSurface" />
-
-            <TextView
-                style="@style/Widget.LoginFlow.TextView.DividerText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:paddingStart="@dimen/margin_small"
-                android:paddingEnd="@dimen/margin_small"
-                android:text="@string/login_or" />
-
-        </FrameLayout>
+            app:layout_constraintVertical_bias="1.0" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/continue_with_google"

--- a/WordPressLoginFlow/src/main/res/layout/login_or_layout.xml
+++ b/WordPressLoginFlow/src/main/res/layout/login_or_layout.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/orLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/margin_medium"
+    android:paddingTop="@dimen/margin_medium">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_gravity="center_vertical"
+        android:alpha="0.12"
+        android:background="?attr/colorOnSurface" />
+
+    <TextView
+        style="@style/Widget.LoginFlow.TextView.DividerText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:paddingEnd="@dimen/margin_small"
+        android:paddingStart="@dimen/margin_small"
+        android:text="@string/login_or" />
+
+</FrameLayout>


### PR DESCRIPTION
This PR extracts the or layout to be later on easily reused. On the newly created shared `login_or_layout` bottom and top padding were added based on its overall usage. This way, every client that is to be using this newly created shared `login_or_layout` will conform to its now defined standards.

Note: As part of this change the `6dp` login layout `layout_marginBottom` was replaced by the inner `8dp` or layout
`paddingBottom` and `paddingTop`. The `paddingTop` change is irrelevant since the `login_email_screen` layout will anyway adjust that automatically. However, the 'paddingBottom' change will have a diff of `2dp`. This change can be also considered as negligible, since it is almost unnoticed.