### PR TITLE
Update FluxC and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,77 +2,18 @@
 
 A pluggable WordPress login flow for Android.
 
-## Usage ##
-
-To use this library in your project, you must set it up as a subtree.
-From the root of your main project, add the subtree:
-
-    $ git subtree add --prefix=libs/login git@github.com:wordpress-mobile/WordPress-Login-Flow-Android.git develop
-
-This will create a new directory, `libs/login`, containing the contents of this repository.
-
-Next, you need to generate the `gradle.properties` file:
-
-    $ cp libs/login/gradle.properties-example libs/login/gradle.properties
-
-Configure the fields in `gradle.properties` to match the `compileSdkVersion`,
-`buildToolsVersion`, `targetSdkVersion`, and support library versions used
-by your project.
-
-At this point, you can add it to your project's root `settings.gradle`:
+## Usage
 
 ```groovy
-include ':libs:login:WordPressLoginFlow'
-```
-
-and to your main app module's `build.gradle` dependencies:
-
-```groovy
+repositories {
+    maven { url "https://a8c-libs.s3.amazonaws.com/android" }
+}
 dependencies {
-
-    releaseCompile (project(path:':libs:login:WordPressLoginFlow', configuration: 'release')) {
-        exclude group: "com.github.wordpress-mobile.WordPress-FluxC-Android", module: "fluxc";
-    }
-    debugCompile (project(path:':libs:login:WordPressLoginFlow', configuration: 'debug')) {
-        exclude group: "com.github.wordpress-mobile.WordPress-FluxC-Android", module: "fluxc";
-    }
-
+    implementation ("org.wordpress:login:$version")
 }
 ```
 
-(The above assumes that you're also using [FluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android)
-in your project, and prevents a duplicated dependency, forcing WordPress-Login-Flow-Android to use
-your project's FluxC config.)
-
-You can also force the login library to use the same FluxC version as your project by declaring the version
-in a `fluxCVersion` variable in your project's root `build.gradle` (and using that same variable anywhere
-else your project uses FluxC):
-
-```groovy
-ext {
-    fluxCVersion = '83baae61804b65cc73a7201a7252750c76066a30'
-}
-```
-
-## Contributing ##
-
-You can fetch the latest changes made to this library into your project using:
-
-    $ git subtree pull --prefix=libs/login git@github.com:wordpress-mobile/WordPress-Login-Flow-Android.git develop --squash
-
-And you can push your own changes upstream to `WordPress-Login-Flow-Android` using:
-
-    $ git subtree push --prefix=libs/login git@github.com:wordpress-mobile/WordPress-Login-Flow-Android.git branch-name
-
-Note: You can add this repository as a remote to simplify the `git subtree push`/`pull` commands:
-
-    $ git remote add loginlib git@github.com:wordpress-mobile/WordPress-Login-Flow-Android.git
-
-This will allow to use this form instead:
-
-    $ git subtree pull --prefix=libs/login loginlib develop --squash
-
-## License ##
+## License
 
 WordPress-Login-Flow-Android is an Open Source project covered by the
 [GNU General Public License version 2](LICENSE.md).

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
-    lintChecks 'org.wordpress:lint:1.0.2'
+    lintChecks 'org.wordpress:lint:1.1.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:2.28.2'

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -24,6 +24,13 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.automattic.android.publish-library-to-s3'
 
 repositories {
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android"
+        content {
+            includeGroup "org.wordpress"
+            includeGroup "org.wordpress.fluxc"
+        }
+    }
     mavenCentral()
     google()
     jcenter()
@@ -59,17 +66,9 @@ dependencies {
 
     api 'com.google.android.gms:play-services-auth:18.1.0'
 
-    // Share FluxC version from host project if defined, otherwise fallback to default
-    if (project.hasProperty("fluxCVersion")) {
-        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:$fluxCVersion") {
-            exclude group: "com.android.support"
-            exclude group: "org.wordpress", module: "utils"
-        }
-    } else {
-        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.17.0") {
-            exclude group: "com.android.support"
-            exclude group: "org.wordpress", module: "utils"
-        }
+    implementation("org.wordpress:fluxc:1.23.0") {
+        exclude group: "com.android.support"
+        exclude group: "org.wordpress", module: "utils"
     }
 
     implementation 'com.github.bumptech.glide:glide:4.12.0'


### PR DESCRIPTION
This PR updates FluxC to `1.23.0` which is published to S3. It updates `org.wordpress:lint` to `1.1.0` which fixes a warning. It also simplifies the README because we no longer have subtrees in WPAndroid & WCAndroid projects. I deliberately made the instructions very simple so it won't be outdated easily.

There are two changes that might be worth explaining:
* Removal of `project.hasProperty("fluxCVersion")` check for fluxc dependency declaration
* Removal of `exclude group` instructions from README

Both of these changes were made for the same reason. Since the project is no longer a subtree, the client's FluxC version is irrelevant to this library - at least for its release. If there is a conflict, it's up to the clients to address them in their own build files.

Furthermore, FluxC is added as a transitive dependency (`implementation`) to the project. So, when Gradle finds the FluxC dependency in the client project as a regular dependency, it should always pick that over the transitive dependency *if the dependency declaration matches*. Meaning the group and module information are the same for each dependency. If they are brought as different dependencies, it will result in duplicate class error.

**To test:**
* As long as CI is green, we are good