### PR TITLE
Show network error on connect site info error

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -369,8 +369,11 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
                     event.error.message);
 
             AppLog.e(T.API, "onFetchedConnectSiteInfo has error: " + event.error.message);
-
-            showError(R.string.invalid_site_url_message);
+            if (NetworkUtils.isNetworkAvailable(requireContext())) {
+                showError(R.string.invalid_site_url_message);
+            } else {
+                showError(R.string.error_generic_network);
+            }
 
             endProgressIfNeeded();
         } else {


### PR DESCRIPTION
Parent issue https://github.com/woocommerce/woocommerce-android/issues/3767

When connectSiteInfo request fails, the app runs a check and shows "no network" error when the device is offline. Previously it showed misleading ` “site URL entered is invalid”` error)

To test:
Test in WCAndroid - https://github.com/woocommerce/woocommerce-android/pull/4800

