### PR TITLE
Upgrade gradle to 7.1.1 agp to 4.2.2

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.automattic.android:publish-to-s3:0.4.2'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is a smaller changeset than the usual Gradle 7 upgrade PRs to enable the composite build so @malinajirka can utilize it. I'll re-visit this library after my support rotation for cleanup, plugin DSL etc.

**To test:**
* Smoke test WPAndroid with binary dependency that'll be published by CI
* Smoke test WPAndroid using this library as composite build following [these instructions](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/local-builds.gradle-example)

Note that I didn't have time to test this in WPAndroid, but I can't imagine it failing 😅 