### PR TITLE
Upgrade to Android 11

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -38,11 +38,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdkVersion 24
+        targetSdkVersion 30
 
         vectorDrawables.useSupportLibrary = true
     }

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -41,7 +41,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 21
         targetSdkVersion 30
 
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
Fixes [WordPress-Android#15340](https://github.com/wordpress-mobile/WordPress-Android/issues/15340)

Upgrade to Android 11 (API level 30)

Please see paqN3M-mr-p2 for details on mandatory requirement to upgrade to Android 11 by November 2021.

- upgrade `targetSdkVersion`, `compileSdkVersion` to 30
