### PR TITLE
Run XML-RPC discovery during SiteAddress login flow in WCAndroid

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -426,6 +426,14 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
             // Not a WordPress site
             mLoginListener.handleSiteAddressError(siteInfo);
         } else {
+            /**
+             * Jetpack internally uses xml-rpc protocol. Due to a bug on the API, when jetpack is
+             * setup and connected to a .com account `isJetpackConnected` returns false when xml-rpc
+             * is disabled.
+             * This is causing issues to the client apps as they can't differentiate between
+             * "xml-rpc disabled" and "jetpack not connected" states. Therefore, the login flow
+             * library always needs to invoke "xml-rpc discovery" to check if xml-rpc is accessible.
+             */
             initiateDiscovery();
         }
     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -407,7 +407,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
             mAnalyticsListener.trackConnectedSiteInfoSucceeded(createConnectSiteInfoProperties(event.info, hasJetpack));
 
             if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
-                handleConnectSiteInfoForWoo(event.info, hasJetpack);
+                handleConnectSiteInfoForWoo(event.info);
             } else if (mLoginListener.getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY) {
                 handleConnectSiteInfoForJetpack(event.info);
             } else {
@@ -416,13 +416,13 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         }
     }
 
-    private void handleConnectSiteInfoForWoo(ConnectSiteInfoPayload siteInfo, boolean hasJetpack) {
-        endProgressIfNeeded();
-
+    private void handleConnectSiteInfoForWoo(ConnectSiteInfoPayload siteInfo) {
         if (!siteInfo.exists) {
+            endProgressIfNeeded();
             // Site does not exist
             showError(R.string.invalid_site_url_message);
         } else if (!siteInfo.isWordPress) {
+            endProgressIfNeeded();
             // Not a WordPress site
             mLoginListener.handleSiteAddressError(siteInfo);
         } else {

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -337,7 +337,15 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         // hold the URL in a variable to use below otherwise it gets cleared up by endProgress
         String inputSiteAddress = mRequestedSiteAddress;
         endProgress();
-        mLoginListener.gotXmlRpcEndpoint(inputSiteAddress, endpointAddress);
+        if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
+            mLoginListener.gotConnectedSiteInfo(
+                    mConnectSiteInfoUrl,
+                    mConnectSiteInfoUrlRedirect,
+                    mConnectSiteInfoCalculatedHasJetpack
+                                               );
+        } else {
+            mLoginListener.gotXmlRpcEndpoint(inputSiteAddress, endpointAddress);
+        }
     }
 
     private void askForHttpAuthCredentials(@NonNull final String url) {
@@ -418,10 +426,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
             // Not a WordPress site
             mLoginListener.handleSiteAddressError(siteInfo);
         } else {
-            mLoginListener.gotConnectedSiteInfo(
-                    siteInfo.url,
-                    siteInfo.urlAfterRedirects,
-                    hasJetpack);
+            initiateDiscovery();
         }
     }
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -67,6 +67,10 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
     private String mRequestedSiteAddress;
 
+    private String mConnectSiteInfoUrl;
+    private String mConnectSiteInfoUrlRedirect;
+    private Boolean mConnectSiteInfoCalculatedHasJetpack;
+
     private LoginSiteAddressValidator mLoginSiteAddressValidator;
 
     @Inject AccountStore mAccountStore;
@@ -151,6 +155,11 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
         if (savedInstanceState != null) {
             mRequestedSiteAddress = savedInstanceState.getString(KEY_REQUESTED_SITE_ADDRESS);
+            mConnectSiteInfoUrl = savedInstanceState.getString(KEY_SITE_INFO_URL);
+            mConnectSiteInfoUrlRedirect =
+                    savedInstanceState.getString(KEY_SITE_INFO_URL_AFTER_REDIRECTS);
+            mConnectSiteInfoCalculatedHasJetpack =
+                    savedInstanceState.getBoolean(KEY_SITE_INFO_CALCULATED_HAS_JETPACK);
         } else {
             mAnalyticsListener.trackUrlFormViewed();
         }
@@ -184,6 +193,10 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         super.onSaveInstanceState(outState);
 
         outState.putString(KEY_REQUESTED_SITE_ADDRESS, mRequestedSiteAddress);
+        outState.putString(KEY_SITE_INFO_URL, mConnectSiteInfoUrl);
+        outState.putString(KEY_SITE_INFO_URL_AFTER_REDIRECTS, mConnectSiteInfoUrlRedirect);
+        outState.putBoolean(KEY_SITE_INFO_CALCULATED_HAS_JETPACK,
+                mConnectSiteInfoCalculatedHasJetpack);
     }
 
     @Override public void onDestroyView() {
@@ -228,6 +241,9 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
     @Override
     public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+        mConnectSiteInfoUrl = null;
+        mConnectSiteInfoUrlRedirect = null;
+        mConnectSiteInfoCalculatedHasJetpack = null;
     }
 
     @Override
@@ -375,6 +391,10 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
             endProgressIfNeeded();
         } else {
             boolean hasJetpack = calculateHasJetpack(event.info);
+
+            mConnectSiteInfoUrl = event.info.url;
+            mConnectSiteInfoUrlRedirect = event.info.urlAfterRedirects;
+            mConnectSiteInfoCalculatedHasJetpack = hasJetpack;
 
             mAnalyticsListener.trackConnectedSiteInfoSucceeded(createConnectSiteInfoProperties(event.info, hasJetpack));
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-android/issues/3767

[WCAndroid PR here](https://github.com/woocommerce/woocommerce-android/pull/4799)

This PR fixes WCAndroid app which is showing "Jetpack not connected" screen even when Jetpack is connected. This is caused by a bug on the api - `isJetpackConnected` returns `false` when xml-rpc is disabled.

This PR fixes this issue by always running "xml-rpc discovery" in the SiteAddress login flow. This will have some performance impact, since we'll need to run an extra request, but should significantly help with login issues as the error messages contain specific instructions.

Some more details on p91TBi-5Y9-p2

Heads-up: I'm not too familiar with the login flows and I might be missing something, so please review this PR carefully. Thanks ;).

<img width="761" alt="Screenshot 2021-09-16 at 15 38 10" src="https://user-images.githubusercontent.com/2261188/133622300-70da5e04-75ae-48a8-978a-fd83f394b8c0.png">

To test:
- the app will now run "xml-rpc discovery" and [show all these errors](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/blob/d8fed0c19087ce27ce7577ba59d53f586edc5763/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java#L274)
- [the ssl error is not handled in the woo app and it's out of the scope of this PR](https://github.com/woocommerce/woocommerce-android/blob/cba1cc6c2201f291d383e1d2fad4582146a66928/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt#L445) - I'd suggest logging an exception as the first step -> I still consider this PR as an enhancement even though this scenario is still not handled


1. Test site address login in the woo app - valid and invalid cases (anything you can think of). 

I tested 
- Jetpack not connected(https://easy-rhino.jurassic.ninja) - jetpack not connected error shown
- Jetpack connected but xmlrpc disabled [using .htaaccess method](https://www.wpbeginner.com/plugins/how-to-disable-xml-rpc-in-wordpress/) (https://deep-louse.jurassic.ninja) - xmlrpc error shown
- Jetpack not installed (https://supposed-nurse.jurassic.ninja) - jetpack not connected error shown
- Working site - the user gets redirected to email login flow
- Blocked XML-RPC (405 error) - (I used site from FluxC's testing properties) - xmlrpc error shown
- Missing XML-RPC methods - (I used site from FluxC's testing properties) - xmlrpc error shown
- Forbidden XML-RPC (403 error) - (I used site from FluxC's testing properties) - xmlrpc error shown
- Http auth enabled(https://assistant-magpie.jurassic.ninja)⚠️ This scenario still doesn't work -> the app shows `http auth` dialog and accepts only valid credentials -> but `/v1.1/connect/site-info/` returns "jetpack not connected" even though jetpack is connected ([Ticket here](https://github.com/woocommerce/woocommerce-android/issues/4282))
```
exists: true
 hasJetpack: true
 isJetpackActive: false
 isJetpackConnected: false
 isWordPress: true
 isWordPressDotCom: false
 jetpackVersion: "10.1"
 skipRemoteInstall: true
 urlAfterRedirects: https://assistant-magpie.jurassic.ninja
```



cc @designsimply I'm not too familiar with the login flow and this change feels a bit risky. Could you perhaps find someone who could thoroughly test this to limit the chance we'll need to work on time-critical beta fixes? Thank you!


 P.S. I plan to log the remaining issues 
- http auth enabled
- self-signed ssl

when this PR is merged. In case we'd find some more errors or someone would have an idea for an easy fix.