### PR TITLE
Skip xmlrpc discovery when jetpack ready

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -428,6 +428,13 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
             endProgressIfNeeded();
             // Not a WordPress site
             mLoginListener.handleSiteAddressError(siteInfo);
+        } else if (siteInfo.hasJetpack && siteInfo.isJetpackConnected && siteInfo.isJetpackActive) {
+            endProgressIfNeeded();
+            mLoginListener.gotConnectedSiteInfo(
+                    mConnectSiteInfoUrl,
+                    mConnectSiteInfoUrlRedirect,
+                    mConnectSiteInfoCalculatedHasJetpack
+            );
         } else {
             /**
              * Jetpack internally uses xml-rpc protocol. Due to a bug on the API, when jetpack is
@@ -435,7 +442,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
              * is disabled.
              * This is causing issues to the client apps as they can't differentiate between
              * "xml-rpc disabled" and "jetpack not connected" states. Therefore, the login flow
-             * library always needs to invoke "xml-rpc discovery" to check if xml-rpc is accessible.
+             * library needs to invoke "xml-rpc discovery" to check if xml-rpc is accessible.
              */
             initiateDiscovery();
         }


### PR DESCRIPTION
This PR builds on top of https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/67. When a site responds with "jetpack connected and active" the app knows that Jetpack connection is working without issues and it can skip the xml-rpc check. This should fix an issue discovered by @designsimply 

```
https://wordpress.org/plugins/disable-xml-rpc-api/
When I tried to use the store address > site credentials flow to log in while this plugin is enabled, the error incorrectly tells me that the site at my address is not a valid WordPress site.
```

To test in WCAndroid:
1. Install "disable-xml-rpc-api plugin
2. Go into its settings and make sure Jetpack is whitelisted
3. Open "Site address" login flow
4. Enter url of the site
5. Make sure it redirects you to the ".com" login and does NOT display "Not a wordpress site" error


