### PR TITLE
Use non-nullable boolean

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -69,7 +69,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
     private String mConnectSiteInfoUrl;
     private String mConnectSiteInfoUrlRedirect;
-    private Boolean mConnectSiteInfoCalculatedHasJetpack;
+    private boolean mConnectSiteInfoCalculatedHasJetpack;
 
     private LoginSiteAddressValidator mLoginSiteAddressValidator;
 
@@ -243,7 +243,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
     public void beforeTextChanged(CharSequence s, int start, int count, int after) {
         mConnectSiteInfoUrl = null;
         mConnectSiteInfoUrlRedirect = null;
-        mConnectSiteInfoCalculatedHasJetpack = null;
+        mConnectSiteInfoCalculatedHasJetpack = false;
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a NPE introduced in [this PR](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/67).

We were using java's nullable Boolean instead of non-nullable boolean. When we tried to store this value into a bundle, the app crashed with NPE as `Bundle.putBoolean` accepts `boolean` so when we pass a null `Boolean` the automatic cast results in NPE.

Test in WCAndroid:
1. Clear app data
2. Enable Do not keep activities in developer settings
3. Click on the Login with site address.
4. Tap no the home button and bring the app back to foreground - notice it doesn't crash


cc @jkmassel ~@AliSoftware~ ~Unfortunately, this bug affects both WPAndroid and WCAndroid 😞.~ (Update: I take that back, it seems that WPAndroid still uses v0.0.4 so this bug affects only WCAndroid). I've created `release/0.0.6` branch to make sure we don't merge any other changes into the beta release. Having said that, if you prefer to merge this PR directly into develop, feel free to do so.