### PR TITLE
Change color of tos text

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -316,7 +316,8 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     }
 
     private Spanned formatTosText(int stringResId) {
-        final int primaryColorResId = ContextExtensionsKt.getColorResIdFromAttribute(getContext(), R.attr.colorSecondary);
+        final int primaryColorResId = ContextExtensionsKt.getColorResIdFromAttribute(getContext(),
+                R.attr.colorSecondary);
         final String primaryColorHtml = HtmlUtils.colorResToHtmlColor(getContext(), primaryColorResId);
         return Html.fromHtml(getString(stringResId, "<u><font color='" + primaryColorHtml + "'>", "</font></u>"));
     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -316,7 +316,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     }
 
     private Spanned formatTosText(int stringResId) {
-        final int primaryColorResId = ContextExtensionsKt.getColorResIdFromAttribute(getContext(), R.attr.colorPrimary);
+        final int primaryColorResId = ContextExtensionsKt.getColorResIdFromAttribute(getContext(), R.attr.colorSecondary);
         final String primaryColorHtml = HtmlUtils.colorResToHtmlColor(getContext(), primaryColorResId);
         return Html.fromHtml(getString(stringResId, "<u><font color='" + primaryColorHtml + "'>", "</font></u>"));
     }


### PR DESCRIPTION
Fixes #4185 

## Changes

Changes the TOS link color in the login screen for the WooCommerce App **(PR [#4972](https://github.com/woocommerce/woocommerce-android/pull/4972))**

Please note we have also tested the changes to the WordPress App and the PR can be found **[here]( https://github.com/wordpress-mobile/WordPress-Android/pull/15436 )**

## Screenshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/136550819-dea5ae2b-97dd-487a-b875-0a2709ae583e.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/136550829-7cb55203-a993-41b3-8208-acb3d7984b75.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/136550901-d4956beb-f906-4ac9-86fd-fe01760bfe05.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/136550919-a283ff1b-ca54-47ad-9bc9-3dd0596841d0.png" width="350"/> |

## Testing Instructions

- Open the app while logged out
-  tap on Continue with WordPress.com
- See the TOS links below the email field and Google Login

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.