### PR TITLE
Check only isJetpackConnected when checking Jetpack status for Woo

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -428,7 +428,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
             endProgressIfNeeded();
             // Not a WordPress site
             mLoginListener.handleSiteAddressError(siteInfo);
-        } else if (siteInfo.hasJetpack && siteInfo.isJetpackConnected && siteInfo.isJetpackActive) {
+        } else if (mConnectSiteInfoCalculatedHasJetpack) {
             endProgressIfNeeded();
             mLoginListener.gotConnectedSiteInfo(
                     mConnectSiteInfoUrl,


### PR DESCRIPTION
Currently, when we get the `/connect/site-info` response for a site, we check the three flags `isJetpackActive`, `hasJetpack` and `isJetpackConnected`, this was implemented just recently (https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/68), while before we were using the field `mConnectSiteInfoCalculatedHasJetpack` which reads only `isJetpackConnected` for non-atomic sites (reason as explained in the comments p99K0U-1vO-p2#comment-3574).

This PR restores this behavior, as it's needed for sites that uses Jetpack Connection Package, since, for those, Jetpack is not installed, and `hasJetpack` will be likely false*

*The backend is broken currently, and returns `true` for the fields `hasJetpack` and `isJetpackActive`, but it's a known bug, that will be fixed later.

### Tests
This just restores the behavior to what was done before https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/67 for Jetpack connected sites, so hopefully it shouldn't break anything.
Just confirming that the login works with an atomic site and a self hosted site should be enough.

Woo PR: https://github.com/woocommerce/woocommerce-android/pull/5099