### PR TITLE
Filtering out CP connected sites for WPMobile only.

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     api 'com.google.android.gms:play-services-auth:18.1.0'
 
-    implementation("org.wordpress:fluxc:1.23.0") {
+    implementation("org.wordpress:fluxc:trunk-9f5f5ea43dd60152677092b499980898f9521f6c") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -336,7 +336,7 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
             mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
         } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
             // The user's account settings have also been fetched and stored - now we can fetch the user's sites
-            FetchSitesPayload payload = SiteUtils.getFetchSitesPayload(isJetpackAppLogin());
+            FetchSitesPayload payload = SiteUtils.getFetchSitesPayload(isJetpackAppLogin(), isWooAppLogin());
             mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(payload));
             mDispatcher.dispatch(AccountActionBuilder.newFetchSubscriptionsAction());
         }
@@ -345,6 +345,11 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
     protected boolean isJetpackAppLogin() {
         return (mLoginListener instanceof LoginListener)
                && ((LoginListener) mLoginListener).getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY;
+    }
+
+    protected boolean isWooAppLogin() {
+        return (mLoginListener instanceof LoginListener)
+               && ((LoginListener) mLoginListener).getLoginMode() == LoginMode.WOO_LOGIN_MODE;
     }
 
     @SuppressWarnings("unused")

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -285,7 +285,8 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
                 mIdToken,
                 mService,
                 mIsSocialLogin,
-                mLoginListener.getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY
+                mLoginListener.getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY,
+                mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE
         );
         mOldSitesIDs = SiteUtils.getCurrentSiteIds(mSiteStore, false);
     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
@@ -45,6 +45,7 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
     private static final String ARG_SOCIAL_ID_TOKEN = "ARG_SOCIAL_ID_TOKEN";
     private static final String ARG_SOCIAL_LOGIN = "ARG_SOCIAL_LOGIN";
     private static final String ARG_JETPACK_APP_LOGIN = "ARG_JETPACK_APP_LOGIN";
+    private static final String ARG_WOO_APP_LOGIN = "ARG_WOO_APP_LOGIN";
     private static final String ARG_SOCIAL_SERVICE = "ARG_SOCIAL_SERVICE";
 
     public enum LoginStep {
@@ -159,6 +160,7 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
     private String mService;
     private boolean mIsSocialLogin;
     private boolean mIsJetpackAppLogin;
+    private boolean mIsWooAppLogin;
 
     public static void loginWithEmailAndPassword(
             Context context,
@@ -166,7 +168,8 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
             String password,
             String idToken, String service,
             boolean isSocialLogin,
-            boolean isJetpackAppLogin) {
+            boolean isJetpackAppLogin,
+            boolean isWooAppLogin) {
         Intent intent = new Intent(context, LoginWpcomService.class);
         intent.putExtra(ARG_EMAIL, email);
         intent.putExtra(ARG_PASSWORD, password);
@@ -174,6 +177,7 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
         intent.putExtra(ARG_SOCIAL_SERVICE, service);
         intent.putExtra(ARG_SOCIAL_LOGIN, isSocialLogin);
         intent.putExtra(ARG_JETPACK_APP_LOGIN, isJetpackAppLogin);
+        intent.putExtra(ARG_WOO_APP_LOGIN, isWooAppLogin);
         context.startService(intent);
     }
 
@@ -263,6 +267,7 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
         mService = intent.getStringExtra(ARG_SOCIAL_SERVICE);
         mIsSocialLogin = intent.getBooleanExtra(ARG_SOCIAL_LOGIN, false);
         mIsJetpackAppLogin = intent.getBooleanExtra(ARG_JETPACK_APP_LOGIN, false);
+        mIsWooAppLogin = intent.getBooleanExtra(ARG_WOO_APP_LOGIN, false);
 
         AuthenticatePayload payload = new AuthenticatePayload(email, password);
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
@@ -382,7 +387,7 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
         } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
             setState(LoginStep.FETCHING_SITES);
             // The user's account settings have also been fetched and stored - now we can fetch the user's sites
-            FetchSitesPayload payload = SiteUtils.getFetchSitesPayload(mIsJetpackAppLogin);
+            FetchSitesPayload payload = SiteUtils.getFetchSitesPayload(mIsJetpackAppLogin, mIsWooAppLogin);
             mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(payload));
         }
     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
@@ -48,9 +48,9 @@ public class SiteUtils {
     }
 
     @NonNull
-    public static FetchSitesPayload getFetchSitesPayload(boolean isJetpackAppLogin) {
+    public static FetchSitesPayload getFetchSitesPayload(boolean isJetpackAppLogin, boolean isWooAppLogin) {
         ArrayList<SiteFilter> siteFilters = new ArrayList<>();
         if (isJetpackAppLogin) siteFilters.add(SiteFilter.JETPACK);
-        return new FetchSitesPayload(siteFilters);
+        return new FetchSitesPayload(siteFilters, !isJetpackAppLogin && !isWooAppLogin);
     }
 }


### PR DESCRIPTION
**IMPORTANT: this is ready to be reviewed; but since it has implications for Woo and JetPack as well, keeping it as a draft so it is not accidentally merged before the validation from WP/JP Android and WooAndroid point of view.**

Part of [WPMobile 15540](https://github.com/wordpress-mobile/WordPress-Android/issues/15540) this PR aims to filter out the CP connected sites for WPMobile only.

There is a [FluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2263) and a [WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/pull/15895) companion PRs.

Appreciate all the **testing you could provide for the login/signup flow paths**.

For **WPAndroid specific issue**, you can follow the test instructions in the companion relevant PR above. @ashiagr note that for JetPack app I'm not filtering out the CP connected sites for now, since sites that have the Jetpack Backup plugin (even without the full JP) fall under this category but I think should be managed by the Jetpack app, whereas those kind of sites as of now should be added as self-hosted sites in WPAndroid. Not sure though about what kind of issues those sites could create for the Jetpack app.

Note that the FluxC PR is not a breaking one, since it allows legacy behaviour with overloads; but AFAIU **when Woo is going to update to this new version of the login library,** we need Woo to also update the Fluxc to be >= trunk-9f5f5ea43dd60152677092b499980898f9521f6c
So that the linked fluxc contains the overloaded version of FetchSitesPayload. I think that makes sense to have a woo small PR to already bring this ahead, so to not forget about it and have problems later. Wdyt @hichamboushaba ?

NOTE: The fluxc version linked from the login lib is pretty old (1.23.0); I linked to the current trunk and smoke tested the flow paths at my best without issues, but as said I would appreciate other pair of eyes on the different login/signup flow paths for all the 3 apps 🙇 .




