### PR TITLE
Enable hiding the "Check email" button on the Signup magic link screen

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
@@ -13,7 +13,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -41,6 +42,7 @@ public class SignupMagicLinkFragment extends Fragment {
     private static final String ARG_EMAIL_ADDRESS = "ARG_EMAIL_ADDRESS";
     private static final String ARG_IS_JETPACK_CONNECT = "ARG_IS_JETPACK_CONNECT";
     private static final String ARG_JETPACK_CONNECT_SOURCE = "ARG_JETPACK_CONNECT_SOURCE";
+    private static final String ARG_IS_EMAIL_CLIENT_AVAILABLE = "ARG_IS_EMAIL_CLIENT_AVAILABLE";
     private static final String SIGNUP_FLOW_NAME = "mobile-android";
 
     public static final String TAG = "signup_magic_link_fragment_tag";
@@ -58,11 +60,20 @@ public class SignupMagicLinkFragment extends Fragment {
 
     public static SignupMagicLinkFragment newInstance(String email, boolean isJetpackConnect,
                                                       String jetpackConnectSource) {
-        SignupMagicLinkFragment fragment = new SignupMagicLinkFragment();
+        return newInstance(email, isJetpackConnect, jetpackConnectSource, null);
+    }
+
+    public static SignupMagicLinkFragment newInstance(String email, boolean isJetpackConnect,
+                                                      String jetpackConnectSource,
+                                                      Boolean isEmailClientAvailable) {
         Bundle args = new Bundle();
         args.putString(ARG_EMAIL_ADDRESS, email);
         args.putBoolean(ARG_IS_JETPACK_CONNECT, isJetpackConnect);
         args.putString(ARG_JETPACK_CONNECT_SOURCE, jetpackConnectSource);
+        if (isEmailClientAvailable != null) {
+            args.putBoolean(ARG_IS_EMAIL_CLIENT_AVAILABLE, isEmailClientAvailable);
+        }
+        SignupMagicLinkFragment fragment = new SignupMagicLinkFragment();
         fragment.setArguments(args);
         return fragment;
     }
@@ -78,19 +89,38 @@ public class SignupMagicLinkFragment extends Fragment {
         setHasOptionsMenu(true);
     }
 
+    /** Determines whether to hide the "Check email button".
+     * When we know that the email client is not available, rather than toasting an error, we hide the button instead.
+     * @return
+     */
+    private boolean shouldHideButton() {
+        Bundle args = getArguments();
+        // preserve default behavior
+        if (args == null || !args.containsKey(ARG_IS_EMAIL_CLIENT_AVAILABLE)) {
+            return false;
+        }
+        // hide button if we know the client is not available
+        return !args.getBoolean(ARG_IS_EMAIL_CLIENT_AVAILABLE);
+    }
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View layout = inflater.inflate(R.layout.signup_magic_link_screen, container, false);
 
         mOpenMailButton = layout.findViewById(R.id.signup_magic_link_button);
-        mOpenMailButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                if (mLoginListener != null) {
-                    mLoginListener.openEmailClient(false);
+
+        if (shouldHideButton()) {
+            mOpenMailButton.setVisibility(View.GONE);
+        } else {
+            mOpenMailButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    if (mLoginListener != null) {
+                        mLoginListener.openEmailClient(false);
+                    }
                 }
-            }
-        });
+            });
+        }
 
         if (getArguments() != null) {
             mIsJetpackConnect = getArguments().getBoolean(ARG_IS_JETPACK_CONNECT);


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Android/issues/15883

#### Related PR: https://github.com/wordpress-mobile/WordPress-Android/pull/15911

### Description

This PR exposes a new factory method for creating the `SignupMagicLinkFragment` which allows specifying whether the default email client is available. If it is not available, the "Check email" button will be hidden.