### PR TITLE
Xmlrpc login errors.

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     api 'com.google.android.gms:play-services-auth:18.1.0'
 
-    implementation("org.wordpress:fluxc:2280-14864a00293531e34f29345b5abd949e2cc20b47") {
+    implementation("org.wordpress:fluxc:trunk-1436f46fc296ede0e65e117bbfced38fa34cec6d") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     api 'com.google.android.gms:play-services-auth:18.1.0'
 
-    implementation("org.wordpress:fluxc:1.23.0") {
+    implementation("org.wordpress:fluxc:2280-dfbdcdde73db70e3919425aca6d403fba918798b") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     api 'com.google.android.gms:play-services-auth:18.1.0'
 
-    implementation("org.wordpress:fluxc:2280-dfbdcdde73db70e3919425aca6d403fba918798b") {
+    implementation("org.wordpress:fluxc:2280-14864a00293531e34f29345b5abd949e2cc20b47") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginHttpAuthDialogFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginHttpAuthDialogFragment.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
@@ -27,15 +28,22 @@ public class LoginHttpAuthDialogFragment extends DialogFragment {
     public static final int DO_HTTP_AUTH = Activity.RESULT_FIRST_USER + 1;
 
     public static final String ARG_URL = "ARG_URL";
+    public static final String ARG_MESSAGE = "ARG_MESSAGE";
     public static final String ARG_USERNAME = "ARG_USERNAME";
     public static final String ARG_PASSWORD = "ARG_PASSWORD";
 
     private String mUrl;
+    private String mMessage;
 
     public static LoginHttpAuthDialogFragment newInstance(@NonNull final String url) {
+        return newInstance(url, "");
+    }
+
+    public static LoginHttpAuthDialogFragment newInstance(@NonNull final String url, @NonNull final String message) {
         LoginHttpAuthDialogFragment fragment = new LoginHttpAuthDialogFragment();
         Bundle args = new Bundle();
         args.putString(ARG_URL, url);
+        args.putString(ARG_MESSAGE, message);
         fragment.setArguments(args);
         return fragment;
     }
@@ -45,6 +53,7 @@ public class LoginHttpAuthDialogFragment extends DialogFragment {
         super.onCreate(savedInstanceState);
 
         mUrl = getArguments().getString(ARG_URL);
+        mMessage = getArguments().getString(ARG_MESSAGE);
     }
 
     @NonNull
@@ -52,6 +61,7 @@ public class LoginHttpAuthDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder alert = new MaterialAlertDialogBuilder(getActivity());
         alert.setTitle(R.string.http_authorization_required);
+        if (!TextUtils.isEmpty(mMessage)) alert.setMessage(mMessage);
 
         //noinspection InflateParams
         View httpAuth = getActivity().getLayoutInflater().inflate(R.layout.login_alert_http_auth, null);

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -287,7 +287,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
                         });
                 break;
             case HTTP_AUTH_REQUIRED:
-                askForHttpAuthCredentials(failedEndpoint);
+                askForHttpAuthCredentials(failedEndpoint, R.string.login_error_xml_rpc_cannot_read_site_auth_required);
                 break;
             case NO_SITE_ERROR:
                 showError(R.string.no_site_error);
@@ -348,8 +348,11 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         }
     }
 
-    private void askForHttpAuthCredentials(@NonNull final String url) {
-        LoginHttpAuthDialogFragment loginHttpAuthDialogFragment = LoginHttpAuthDialogFragment.newInstance(url);
+    private void askForHttpAuthCredentials(@NonNull final String url, int messageId) {
+        LoginHttpAuthDialogFragment loginHttpAuthDialogFragment = LoginHttpAuthDialogFragment.newInstance(
+                url,
+                getString(messageId)
+        );
         loginHttpAuthDialogFragment.setTargetFragment(this, LoginHttpAuthDialogFragment.DO_HTTP_AUTH);
         loginHttpAuthDialogFragment.show(getFragmentManager(), LoginHttpAuthDialogFragment.TAG);
     }

--- a/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -46,6 +46,10 @@
     <string name="login_find_your_connected_email">Find your connected email</string>
     <string name="login_checking_site_address">Checking site address</string>
     <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
+    <string name="login_error_xml_rpc_services_disabled">XML-RPC services are disabled on this site.</string>
+    <string name="login_error_xml_rpc_cannot_read_site">Unable to read the WordPress site at that URL. Tap on help icon to view the FAQ.</string>
+    <string name="login_error_xml_rpc_cannot_read_site_auth_required">XML-RPC calls seem blocked on this site (error code 401). If attempt to login fails tap on help icon to view the FAQ.</string>
+    <string name="login_error_xml_rpc_auth_error_communicating">There was a problem communicating with the site. An HTTP error code 401 was returned.</string>
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
     <string name="login_invalid_site_url">Please enter a complete website address, like example.com.</string>


### PR DESCRIPTION
IMPORTANT: this is ready to be reviewed; but since it has implications for Woo as well, keeping it as a draft so it is not accidentally merged before the validation from WPAndroid and WooAndroid point of view.

This is part of https://github.com/wordpress-mobile/WordPress-Android/issues/12401.

I tried to keep the current behaviors for NON-SelfHosted sited not affected, only adding a couple of enums in FluxC mapping the various errors conditions for xml-rpc, that are used/parsed only in the login flow for now. This should reduce the possibility of regressions but appreciate testing of the various log-in/sign-up scenarios 🙇 .

See the https://github.com/wordpress-mobile/WordPress-Android/pull/15919 for more details.