### PR TITLE
Jetpack App: Remove Jetpack filtering for sites

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
@@ -50,7 +50,6 @@ public class SiteUtils {
     @NonNull
     public static FetchSitesPayload getFetchSitesPayload(boolean isJetpackAppLogin) {
         ArrayList<SiteFilter> siteFilters = new ArrayList<>();
-        if (isJetpackAppLogin) siteFilters.add(SiteFilter.JETPACK);
         return new FetchSitesPayload(siteFilters);
     }
 }


### PR DESCRIPTION
Parent: https://github.com/wordpress-mobile/WordPress-Android/issues/15916

This PR removes Jetpack filtering for sites for the Jetpack app.