### PR TITLE
Jetpack app: Allow WordPress.com site address login

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -414,7 +414,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
             if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
                 handleConnectSiteInfoForWoo(event.info);
-            } else if (mLoginListener.getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY) {
+            } else if (!event.info.isWPCom && mLoginListener.getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY) {
                 handleConnectSiteInfoForJetpack(event.info);
             } else {
                 handleConnectSiteInfoForWordPress(event.info);


### PR DESCRIPTION
Until now it was fine to display a Jetpack not installed error for `WordPress.com` simple site address login as such sites were filtered inside the `Jetpack app` and did not qualify for login to Jetpack app.

Now that we've removed filtering for Jetpack sites in https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/79, when a site address during login is a `WordPress.com` site (irrespective of `simple` or `atomic` site), we now direct to the `WordPress.com` email login.

See https://github.com/wordpress-mobile/WordPress-Android/pull/16025 for the testing instructions.

Thanks to @thehenrybyrd for reporting this issue here: p5T066-31e-p2#comment-11484