### PR TITLE
(Cherry Pick) Jetpack App: Allow WordPress.com site address login for Jetpack app

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -411,7 +411,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
             if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
                 handleConnectSiteInfoForWoo(event.info);
-            } else if (mLoginListener.getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY) {
+            } else if (!event.info.isWPCom && mLoginListener.getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY) {
                 handleConnectSiteInfoForJetpack(event.info);
             } else {
                 handleConnectSiteInfoForWordPress(event.info);


### PR DESCRIPTION
This PR cherry-picks an already reviewed and merged commit (see: https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/80 for details) so that it targets a correct release branch. 

(cherry picked from commit 246294ddc66acd22d7e92c2c1c8feddb4bb57d2e)