### PR TITLE
Merge release/0.11.1 back to trunk

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -411,7 +411,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
             if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
                 handleConnectSiteInfoForWoo(event.info);
-            } else if (mLoginListener.getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY) {
+            } else if (!event.info.isWPCom && mLoginListener.getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY) {
                 handleConnectSiteInfoForJetpack(event.info);
             } else {
                 handleConnectSiteInfoForWordPress(event.info);


### PR DESCRIPTION
Now that `0.11.1`, which was cut from previous tag `0.11.0` to land a fix specific to the JPAndroid code-frozen beta (see https://github.com/wordpress-mobile/WordPress-Android/pull/16025 then https://github.com/wordpress-mobile/WordPress-Android/pull/16034)), has landed, we need to merge that `release/0.11.1` back to `trunk to reconcile the branches.

PS: I've also [published the GitHub Release for 0.11.1](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/releases/tag/0.11.1)

## Empty Diff & Cherry-Pick

Note that since #82 (which landed on `release/0.11.1`) was already a cherry-pick of #80 (which landed on `trunk`), that's why the diff is empty. Still, in order to make it clear in the git history that this `release/0.11.1` finally landed, it is still a good idea/practice to merge the release branch back to `trunk` anyway, despite the empty diff here, to keep the git graph consistent.

---

EDIT: Strangely, it seems that GitHub still shows a non-empty diff on this PR 🤔  Despite what I explained above, and also the fact that the diff is indeed empty if I do the merge of `release/0.11.1` into `trunk` locally…

I think (?) that this might be because in practice the change from #82 and #80, despite being the same changes, don't end up on the same line number in the end (because unrelated code was added above those lines in the other PRs which landed to `trunk` in-between, shifting the line number), them being [on line 414 in `release/0.11.1`](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/blob/release/0.11.1/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java#L414) but [on line 474 in `trunk`](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/blob/trunk/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java#L417)… so maybe that's why GitHub ends up showing a non-empty diff in its UI? But if you compare those 2 links above manually you can see that they are the same changes anyway 🤷 