### PR TITLE
Update Dagger to 2.42

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 ext {
     kotlin_ktx_version = '1.3.2'
-    daggerVersion = '2.33'
+    daggerVersion = '2.42'
     appCompatVersion = '1.0.2'
 }
 


### PR DESCRIPTION
AGP `7.2.1` update results in a crash during lint due to a bug in Dagger which is addressed in `2.42`. This PR updates Dagger to `2.42` and targets the AGP update branch, so they can be shipped together.