### PR TITLE
Update FluxC to Latest Trunk Hash

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     api 'com.google.android.gms:play-services-auth:18.1.0'
 
-    implementation("org.wordpress:fluxc:1.49.0") {
+    implementation("org.wordpress:fluxc:trunk-e94126bf9eb942d262768f8851cf2c4980e249fc") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -328,10 +328,11 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
     }
 
     private void refreshXmlRpcSites() {
-        RefreshSitesXMLRPCPayload selfHostedPayload = new RefreshSitesXMLRPCPayload();
-        selfHostedPayload.username = mRequestedUsername;
-        selfHostedPayload.password = mRequestedPassword;
-        selfHostedPayload.url = mEndpointAddress;
+        RefreshSitesXMLRPCPayload selfHostedPayload = new RefreshSitesXMLRPCPayload(
+            mRequestedUsername,
+            mRequestedPassword,
+            mEndpointAddress
+        );
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(selfHostedPayload));
     }
 


### PR DESCRIPTION
Relates To:
- WPAndroid: [Update Fluxc and Login Libraries to Latest Trunk Version #17056](https://github.com/wordpress-mobile/WordPress-Android/pull/17056)
- WCAndroid: [Update login library version #7240](https://github.com/woocommerce/woocommerce-android/pull/7240)

This `FluxC` hash updates `FluxC` to that latest 'trunk' version where the `RefreshSitesXMLRPCPayload` data class becomes immutable.

As such, the `refreshXmlRpcSites()` method for the `LoginUsernamePasswordFragment` class needs updating to adhere to this change.

This step is required in order to avoid the client apps like `WPAndroid` and `WCAndroid` crashing while using a newer version of `FluxC` on their side due to transitive dependencies taking precedence and using the latest `FluxC` version, the one defined on the client's side.