### PR TITLE
Update FluxC version to 1.50.0

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     api 'com.google.android.gms:play-services-auth:18.1.0'
 
-    implementation("org.wordpress:fluxc:trunk-e94126bf9eb942d262768f8851cf2c4980e249fc") {
+    implementation("org.wordpress:fluxc:1.50.0") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }


### PR DESCRIPTION
There should be no practical changes due to this version bump. I just wanted to make sure that we are using a FluxC release before creating the `0.18.0` version.