### PR TITLE
Fix a LoginEmailFragment crash

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -210,7 +210,9 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         }
         mEmailInput.post(new Runnable() {
             @Override public void run() {
-                mEmailInput.addTextChangedListener(LoginEmailFragment.this);
+                if (mEmailInput != null) {
+                    mEmailInput.addTextChangedListener(LoginEmailFragment.this);
+                }
             }
         });
 


### PR DESCRIPTION
This PR fixes a common crash in woocommerce/woocommerce-android#7381. It adds a null check, so that when a `Runnable` is executed after the view is destroyed, the app doesn't crash.

I wasn't able to replicate the crash so I don't have any testing instructions but there is no valid app state where the view could be `null` so this fix should do it.