### PR TITLE
Updates compile sdk version and target sdk version to 31 for Android 12 compatibility

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -27,11 +27,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
Closes #96 

This PR updates the target SDK version to 31 for the Android 12 migration

Test Instructions
- Install the app from the Parent PR
- Make sure the functionalities provided by the library work as expected - login 
