### PR TITLE
Updates: fluxC hash version with changes of Android 12

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     api 'com.google.android.gms:play-services-auth:18.1.0'
 
-    implementation("org.wordpress:fluxc:1.50.0") {
+    implementation("org.wordpress:fluxc:trunk-065315b4d0a57112dfe8a37d379431735063bc82") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }


### PR DESCRIPTION
Closes #96 

This PR Updates the FluxC Version of the library being used. As part of the changes for Android 12, this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2533) was merged. Although the changes on Login Flow for Android 12 were done in this [PR](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/97), the fluxC version was not updated. So this PR updates the FluxC Version. 