### PR TITLE
Bump FluxC version to latest stable

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     api 'com.google.android.gms:play-services-auth:18.1.0'
 
-    implementation("org.wordpress:fluxc:trunk-065315b4d0a57112dfe8a37d379431735063bc82") {
+    implementation("org.wordpress:fluxc:2.0.0") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }


### PR DESCRIPTION
There should be no practical changes due to this version bump. I just wanted to make sure that we are using a FluxC release before creating the 1.0.0 version.