### PR TITLE
[Woo] Disable XMLRPC discovery in site address screen

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -429,23 +429,13 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
             endProgressIfNeeded();
             // Not a WordPress site
             mLoginListener.handleSiteAddressError(siteInfo);
-        } else if (mConnectSiteInfoCalculatedHasJetpack) {
+        } else {
             endProgressIfNeeded();
             mLoginListener.gotConnectedSiteInfo(
                     mConnectSiteInfoUrl,
                     mConnectSiteInfoUrlRedirect,
                     mConnectSiteInfoCalculatedHasJetpack
             );
-        } else {
-            /**
-             * Jetpack internally uses xml-rpc protocol. Due to a bug on the API, when jetpack is
-             * setup and connected to a .com account `isJetpackConnected` returns false when xml-rpc
-             * is disabled.
-             * This is causing issues to the client apps as they can't differentiate between
-             * "xml-rpc disabled" and "jetpack not connected" states. Therefore, the login flow
-             * library needs to invoke "xml-rpc discovery" to check if xml-rpc is accessible.
-             */
-            initiateDiscovery();
         }
     }
 


### PR DESCRIPTION
This PR is needed for https://github.com/woocommerce/woocommerce-android/issues/8282

When REST API is supported, we will be handling login using Cookie Nonce authentication, and in this case the XMLRPC discovery is not needed, and the login should work even when XMLRPC is disabled, so we don't need its discovery checks.

Check the WCAndroid [PR](https://github.com/woocommerce/woocommerce-android/pull/8289) for more information.