### PR TITLE
[Compile Warnings As Errors] Resolve Warnings & Enable All Warnings as Errors

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
     plugins: *common_plugins
     command: |
       cp gradle.properties-example gradle.properties
-      ./gradlew lint checkstyle
+      ./gradlew lintRelease checkstyle
     artifact_paths:
       - "**/build/reports/lint-results.*"
       - "**/build/reports/checkstyle/checkstyle.*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,7 +26,7 @@ steps:
     plugins: *common_plugins
     command: |
       cp gradle.properties-example gradle.properties
-      ./gradlew test
+      ./gradlew testRelease
   # Publish tasks
   - label: "Publish to s3"
     depends_on:

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.kt
@@ -78,7 +78,7 @@ interface LoginAnalyticsListener {
         GOOGLE;
 
         fun asPropertyMap() = hashMapOf<String, Any>(
-                "source" to name.toLowerCase(Locale.ROOT)
+                "source" to name.lowercase(Locale.ROOT)
         )
     }
 }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -117,7 +117,7 @@ class SignupConfirmationFragment : Fragment() {
         }
     }
 
-    @Suppress("OVERRIDE_DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         // important for accessibility - talkback

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id 'com.android.library' apply false
+    id 'org.jetbrains.kotlin.android' apply false
+}
+
 ext {
     minSdkVersion = 24
     compileSdkVersion = 33
@@ -50,6 +57,12 @@ allprojects {
         checkstyle {
             toolVersion = '8.3'
             configFile file("${project.rootDir}/config/checkstyle.xml")
+        }
+    }
+
+    tasks.withType(KotlinCompile).all {
+        kotlinOptions {
+            allWarningsAsErrors = true
         }
     }
 }


### PR DESCRIPTION
This PR resolves/suppresses all warnings for all modules and then enables all warnings as errors as the default for this project (776e3ea2fe461ffea74bccb65da66d5a11dc601b).

PS: This is done just to restrict further Kotlin related warnings to creep into this repo and with it to also enable future Kotlin updates, for example see below warning that would have made the Kotlin `1.7` update a bit more in the future:

`Non exhaustive 'when' statements on enum will be prohibited in 1.7, add 'XYZ' branches or 'else' branch instead`

-----

Warnings Resolution List:

1. [Resolve to lower case deprecated warning](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/commit/74530ae88effa83e0e548694b2021b5ad272c6d7)

Warnings Suppression List:

1. [Suppress deprecated warning](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/commit/c223c221da7ed25192029bdba0e4a7043a0cead9)

Lint Restructure List:

1. [Change lint to lint release check](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/commit/9176787d09359138240724d483d3359622c7861d)

Test Restructure List:

1. [Change test to test release check](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/commit/a816a273582d4074e24e5a14d6364932765c33d0)

-----

## To test

1. There is nothing much to test here (if not all, most of the deprecated warnings were suppressed).
3. Verifying that all the CI checks are successful should be enough.