### PR TITLE
[Build] Enable Non-Transitive Resources

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -319,7 +319,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
 
     private Spanned formatTosText(int stringResId) {
         final int primaryColorResId = ContextExtensionsKt.getColorResIdFromAttribute(getContext(),
-                R.attr.colorSecondary);
+                com.google.android.material.R.attr.colorSecondary);
         final String primaryColorHtml = HtmlUtils.colorResToHtmlColor(getContext(), primaryColorResId);
         return Html.fromHtml(getString(stringResId, "<u><font color='" + primaryColorHtml + "'>", "</font></u>"));
     }

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -6,5 +6,7 @@ wp.debug.wpcom_login_username =
 wp.debug.wpcom_login_password =
 wp.debug.wpcom_website_url =
 
+# WordPress-Login-Flow-Android properties.
+
 android.useAndroidX=true
 android.enableJetifier=false

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -10,3 +10,5 @@ wp.debug.wpcom_website_url =
 
 android.useAndroidX=true
 android.enableJetifier=false
+
+android.nonTransitiveRClass=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,13 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.6.10'
     gradle.ext.agpVersion = '7.2.1'
+    gradle.ext.automatticPublishToS3Version = '0.7.0'
 
     plugins {
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
         id "org.jetbrains.kotlin.kapt" version gradle.ext.kotlinVersion
         id "com.android.library" version gradle.ext.agpVersion
-        id "com.automattic.android.publish-to-s3" version "0.7.0"
+        id "com.automattic.android.publish-to-s3" version gradle.ext.automatticPublishToS3Version
     }
     repositories {
         maven {


### PR DESCRIPTION
This PR is a prerequisite for the `Gradle 8.1.1 & AGP 8.0.2 Upgrade for WPAndroid, WCAndroid & Related Libs` project.

Platform Request: `pdnsEh-13V-p2`
Project Thread: `paaHJt-57Z-p2`

-----

This PR enables non-transitive resources (`android.nonTransitiveRClass`) for the project.

FYI: This behavior becomes the default in AGP `8.0` and higher. As such, this becomes a prerequisite for the AGP `8.0.2` upgrade, that is of course, unless `android.nonTransitiveRClass` is explicitly set to `false`.

-----

Dependency Versions Refactor List:

1. [Extract automattic publish to s3 version to settings build gradle](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/118/commits/b584c0325707a722bd83944abc55f831177af6cc)

-----

## To test:

1. Verify that all the CI checks are successful.