### PR TITLE
[Jetpack] Ignore Jetpack CP filter when adding self-hosted sites from Jetpack app

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -344,8 +344,10 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
     }
 
     protected boolean isJetpackAppLogin() {
-        return (mLoginListener instanceof LoginListener)
-               && ((LoginListener) mLoginListener).getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY;
+        if (!(mLoginListener instanceof LoginListener)) return false;
+
+        LoginMode mode = ((LoginListener) mLoginListener).getLoginMode();
+        return mode == LoginMode.JETPACK_LOGIN_ONLY || mode == LoginMode.JETPACK_SELFHOSTED;
     }
 
     protected boolean isWooAppLogin() {

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -157,6 +157,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             case FULL:
             case WPCOM_LOGIN_ONLY:
             case JETPACK_LOGIN_ONLY:
+            case JETPACK_SELFHOSTED:
             case SELFHOSTED_ONLY:
                 if (!TextUtils.isEmpty(mLoginSiteUrl)) {
                     label.setText(Html.fromHtml(

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMode.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMode.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 public enum LoginMode {
     FULL,
     SELFHOSTED_ONLY,
+    JETPACK_SELFHOSTED,
     WPCOM_LOGIN_ONLY,
     JETPACK_LOGIN_ONLY,
     JETPACK_STATS,

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -444,7 +444,8 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
     private void handleConnectSiteInfoForWordPress(ConnectSiteInfoPayload siteInfo) {
         if (siteInfo.isWPCom) {
             // It's a Simple or Atomic site
-            if (mLoginListener.getLoginMode() == LoginMode.SELFHOSTED_ONLY) {
+            LoginMode mode = mLoginListener.getLoginMode();
+            if (mode == LoginMode.SELFHOSTED_ONLY || mode == LoginMode.JETPACK_SELFHOSTED) {
                 // We're only interested in self-hosted sites
                 if (siteInfo.hasJetpack) {
                     // This is an Atomic site, so treat it as self-hosted and start the discovery process


### PR DESCRIPTION
This is part of the fix for: https://github.com/wordpress-mobile/WordPress-Android/issues/18223

Companion PR: https://github.com/wordpress-mobile/WordPress-Android/pull/18952

Since we didn't have a way of identifying if the current login for self-hosted sites was being done from the Jetpack app, the filter for removing Jetpack CP-connected sites was executed, but for the Jetpack app this should never be the case.

This fix introduces a new `LoginMode` for identifying `JETPACK_SELFHOSTED` logins, and reuses the existing logic for `JETPACK_LOGIN_ONLY` for keeping the Jetpack CP-connected sites when fetching all sites.