### PR TITLE
[Nullability Annotations to Java Classes] Update `wordPressLintVersion` to 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
 
 ext {
     // libs
-    wordpressLintVersion = '1.1.0'
+    wordpressLintVersion = '2.0.0'
     wordpressUtilsVersion = '3.5.0'
     wordpressFluxCVersion = '2.21.0'
 


### PR DESCRIPTION
This PR updates `wordPressLintVersion` to [2.0.0](https://github.com/wordpress-mobile/WordPress-Lint-Android/releases/tag/2.0.0).

-----

## To test:

1. Verifying that all the CI checks are successful (focus on the Lint related [check](https://buildkite.com/automattic/wordpress-login-flow-android/builds/167#018b61ba-c664-46d9-9ca2-ac0b9cc6c920) and its [report](N/A)).
2. Verify that the new `MissingNullAnnotationOn*` correctness related rules are reporting as expected. For a reference, see screenshot below:

![image](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/assets/9729923/ad5a963e-5d3d-4086-aa65-00e52c898d12)
