### PR TITLE
2FA code: Added clarity that the code is for WordPress.com

### DIFF
--- a/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="next">Next</string>
     <string name="check_email">Check email</string>
     <string name="open_mail">Open Mail</string>
-    <string name="enter_verification_code">Almost there! Please enter the verification code from your Authenticator app.</string>
+    <string name="enter_verification_code">Almost there! Please enter the verification code for WordPress.com from your authenticator app.</string>
     <string name="enter_verification_code_sms">We sent a text message to the phone number ending in %s. Please enter the verification code in the SMS.</string>
     <string name="login_text_otp">Text me a code instead</string>
     <string name="login_text_otp_another">Text me another code instead</string>


### PR DESCRIPTION
Added clarity to string that the code is for _Wordpress.com_.

This [issue](https://github.com/wordpress-mobile/WordPress-Android/issues/19442) required changes in this repository; hence, edits were made to `strings.xml`.

Ref: pbArwn-6hG-p2