### PR TITLE
Remove fetching user subscriptions on login with 2FA enabled

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -339,7 +339,6 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
             FetchSitesPayload payload =
                     SiteUtils.getFetchSitesPayload(isJetpackAppLogin(), isWooAppLogin());
             mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(payload));
-            mDispatcher.dispatch(AccountActionBuilder.newFetchSubscriptionsAction());
         }
     }
 


### PR DESCRIPTION
Coming from this https://github.com/woocommerce/woocommerce-android/issues/3911 and this Slack convo: p1698668159519919-slack-C0180B5PRJ4

It seems that we are fetcjhing user site subscritions on log in, when 2FA is enabled. This requests seems to be unnecessary as it is not fired for the rest of the login flows (like with 2FA disabled).