### PR TITLE
Issue/support passkey social login

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -158,7 +158,8 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
 
     public static Login2FaFragment newInstanceSocial(String emailAddress, String userId,
                                                      String nonceAuthenticator, String nonceBackup,
-                                                     String nonceSms, String nonceWebauthn) {
+                                                     String nonceSms, String nonceWebauthn,
+                                                     List<String> authTypes) {
         Login2FaFragment fragment = new Login2FaFragment();
         Bundle args = new Bundle();
         args.putString(ARG_EMAIL_ADDRESS, emailAddress);
@@ -170,7 +171,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         args.putBoolean(ARG_2FA_IS_SOCIAL, true);
         // Social account connected, connect call not needed.
         args.putBoolean(ARG_2FA_IS_SOCIAL_CONNECT, false);
-        args.putBoolean(ARG_DISPLAY_SECURITY_KEY_BUTTON, nonceWebauthn != null && !nonceWebauthn.isEmpty());
+        args.putStringArrayList(ARG_2FA_SUPPORTED_AUTH_TYPES, new ArrayList<>(authTypes));
         fragment.setArguments(args);
         return fragment;
     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -150,6 +150,23 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         return fragment;
     }
 
+    public static Login2FaFragment newInstanceSocialSecurityKey(String emailAddress, String userId,
+                                                                String nonceAuthenticator,
+                                                                String nonceBackup, String nonceSms,
+                                                                String webauthnNonce) {
+        Login2FaFragment fragment = new Login2FaFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_EMAIL_ADDRESS, emailAddress);
+        args.putString(ARG_2FA_USER_ID, userId);
+        args.putString(ARG_2FA_NONCE_AUTHENTICATOR, nonceAuthenticator);
+        args.putString(ARG_2FA_NONCE_BACKUP, nonceBackup);
+        args.putString(ARG_2FA_NONCE_SMS, nonceSms);
+        args.putString(ARG_WEBAUTHN_NONCE, webauthnNonce);
+        args.putBoolean(ARG_DISPLAY_SECURITY_KEY_BUTTON, true);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
     public static Login2FaFragment newInstanceSocial(String emailAddress, String userId,
                                                      String nonceAuthenticator, String nonceBackup,
                                                      String nonceSms) {

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -150,26 +150,9 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         return fragment;
     }
 
-    public static Login2FaFragment newInstanceSocialSecurityKey(String emailAddress, String userId,
-                                                                String nonceAuthenticator,
-                                                                String nonceBackup, String nonceSms,
-                                                                String webauthnNonce) {
-        Login2FaFragment fragment = new Login2FaFragment();
-        Bundle args = new Bundle();
-        args.putString(ARG_EMAIL_ADDRESS, emailAddress);
-        args.putString(ARG_2FA_USER_ID, userId);
-        args.putString(ARG_2FA_NONCE_AUTHENTICATOR, nonceAuthenticator);
-        args.putString(ARG_2FA_NONCE_BACKUP, nonceBackup);
-        args.putString(ARG_2FA_NONCE_SMS, nonceSms);
-        args.putString(ARG_WEBAUTHN_NONCE, webauthnNonce);
-        args.putBoolean(ARG_DISPLAY_SECURITY_KEY_BUTTON, true);
-        fragment.setArguments(args);
-        return fragment;
-    }
-
     public static Login2FaFragment newInstanceSocial(String emailAddress, String userId,
                                                      String nonceAuthenticator, String nonceBackup,
-                                                     String nonceSms) {
+                                                     String nonceSms, String nonceWebauthn) {
         Login2FaFragment fragment = new Login2FaFragment();
         Bundle args = new Bundle();
         args.putString(ARG_EMAIL_ADDRESS, emailAddress);
@@ -177,9 +160,11 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         args.putString(ARG_2FA_NONCE_AUTHENTICATOR, nonceAuthenticator);
         args.putString(ARG_2FA_NONCE_BACKUP, nonceBackup);
         args.putString(ARG_2FA_NONCE_SMS, nonceSms);
+        args.putString(ARG_WEBAUTHN_NONCE, nonceWebauthn);
         args.putBoolean(ARG_2FA_IS_SOCIAL, true);
         // Social account connected, connect call not needed.
         args.putBoolean(ARG_2FA_IS_SOCIAL_CONNECT, false);
+        args.putBoolean(ARG_DISPLAY_SECURITY_KEY_BUTTON, nonceWebauthn != null && !nonceWebauthn.isEmpty());
         fragment.setArguments(args);
         return fragment;
     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -239,7 +239,7 @@ public class LoginGoogleFragment extends GoogleFragment {
         } else if (event.requiresTwoStepAuth || Login2FaFragment.TWO_FACTOR_TYPE_SMS.equals(event.notificationSent)) {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - needs 2fa");
             mLoginListener.needs2faSocial(mGoogleEmail, event.userId, event.nonceAuthenticator, event.nonceBackup,
-                    event.nonceSms);
+                    event.nonceSms, event.nonceWebauthn);
         } else {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - success");
             mGoogleListener.onGoogleLoginFinished();

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -239,7 +239,7 @@ public class LoginGoogleFragment extends GoogleFragment {
         } else if (event.requiresTwoStepAuth || Login2FaFragment.TWO_FACTOR_TYPE_SMS.equals(event.notificationSent)) {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - needs 2fa");
             mLoginListener.needs2faSocial(mGoogleEmail, event.userId, event.nonceAuthenticator, event.nonceBackup,
-                    event.nonceSms, event.twoStepTypes);
+                    event.nonceSms, event.nonceWebauthn, event.twoStepTypes);
         } else {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - success");
             mGoogleListener.onGoogleLoginFinished();

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -239,7 +239,7 @@ public class LoginGoogleFragment extends GoogleFragment {
         } else if (event.requiresTwoStepAuth || Login2FaFragment.TWO_FACTOR_TYPE_SMS.equals(event.notificationSent)) {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - needs 2fa");
             mLoginListener.needs2faSocial(mGoogleEmail, event.userId, event.nonceAuthenticator, event.nonceBackup,
-                    event.nonceSms, event.nonceWebauthn);
+                    event.nonceSms, event.twoStepTypes);
         } else {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - success");
             mGoogleListener.onGoogleLoginFinished();

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -53,7 +53,7 @@ public interface LoginListener {
                   String nonceAuthenticator, String nonceBackup, String noncePush,
                   List<String> supportedAuthTypes);
     void needs2faSocial(String email, String userId, String nonceAuthenticator, String nonceBackup,
-                        String nonceSms, List<String> supportedAuthTypes);
+                        String nonceSms, String nonceWebauthn, List<String> supportedAuthTypes);
     void needs2faSocialConnect(String email, String password, String idToken, String service);
     void loggedInViaPassword(ArrayList<Integer> oldSitesIds);
     void helpEmailPasswordScreen(String email);

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -53,7 +53,7 @@ public interface LoginListener {
                   String nonceAuthenticator, String nonceBackup, String noncePush,
                   List<String> supportedAuthTypes);
     void needs2faSocial(String email, String userId, String nonceAuthenticator, String nonceBackup,
-                        String nonceSms, String nonceWebauthn);
+                        String nonceSms, List<String> supportedAuthTypes);
     void needs2faSocialConnect(String email, String password, String idToken, String service);
     void loggedInViaPassword(ArrayList<Integer> oldSitesIds);
     void helpEmailPasswordScreen(String email);

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -48,10 +48,12 @@ public interface LoginListener {
     void forgotPassword(String url);
     void useMagicLinkInstead(String email, boolean verifyEmail);
     void needs2fa(String email, String password);
-    void needs2faSocial(String email, String userId, String nonceAuthenticator, String nonceBackup, String nonceSms, String nonceWebauthn);
+    void needs2faSocial(String email, String userId, String nonceAuthenticator, String nonceBackup,
+                        String nonceSms, String nonceWebauthn);
     void needs2faSocialConnect(String email, String password, String idToken, String service);
     void needs2faSecurityKey(String email, String password, String userId, String webauthnNonce);
-    void needs2faSocialSecurityKey(String email, String userId, String nonceAuthenticator, String nonceBackup, String nonceSms, String webauthnNonce);
+    void needs2faSocialSecurityKey(String email, String userId, String nonceAuthenticator,
+                                   String nonceBackup, String nonceSms, String webauthnNonce);
     void loggedInViaPassword(ArrayList<Integer> oldSitesIds);
     void helpEmailPasswordScreen(String email);
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -51,6 +51,7 @@ public interface LoginListener {
     void needs2faSocial(String email, String userId, String nonceAuthenticator, String nonceBackup, String nonceSms);
     void needs2faSocialConnect(String email, String password, String idToken, String service);
     void needs2faSecurityKey(String email, String password, String userId, String webauthnNonce);
+    void needs2faSocialSecurityKey(String email, String userId, String nonceAuthenticator, String nonceBackup, String nonceSms, String webauthnNonce);
     void loggedInViaPassword(ArrayList<Integer> oldSitesIds);
     void helpEmailPasswordScreen(String email);
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -52,8 +52,6 @@ public interface LoginListener {
                         String nonceSms, String nonceWebauthn);
     void needs2faSocialConnect(String email, String password, String idToken, String service);
     void needs2faSecurityKey(String email, String password, String userId, String webauthnNonce);
-    void needs2faSocialSecurityKey(String email, String userId, String nonceAuthenticator,
-                                   String nonceBackup, String nonceSms, String webauthnNonce);
     void loggedInViaPassword(ArrayList<Integer> oldSitesIds);
     void helpEmailPasswordScreen(String email);
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -48,7 +48,7 @@ public interface LoginListener {
     void forgotPassword(String url);
     void useMagicLinkInstead(String email, boolean verifyEmail);
     void needs2fa(String email, String password);
-    void needs2faSocial(String email, String userId, String nonceAuthenticator, String nonceBackup, String nonceSms);
+    void needs2faSocial(String email, String userId, String nonceAuthenticator, String nonceBackup, String nonceSms, String nonceWebauthn);
     void needs2faSocialConnect(String email, String password, String idToken, String service);
     void needs2faSecurityKey(String email, String password, String userId, String webauthnNonce);
     void needs2faSocialSecurityKey(String email, String userId, String nonceAuthenticator, String nonceBackup, String nonceSms, String webauthnNonce);

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
@@ -269,7 +269,7 @@ public class SignupGoogleFragment extends GoogleFragment {
             AppLog.d(T.MAIN, "GOOGLE SIGNUP: onSocialChanged - 2fa required");
             mAnalyticsListener.trackSignupSocialToLogin();
             mLoginListener.needs2faSocial(mGoogleEmail, event.userId, event.nonceAuthenticator, event.nonceBackup,
-                    event.nonceSms, event.nonceWebauthn);
+                    event.nonceSms, event.twoStepTypes);
             finishFlow();
         } else {
             AppLog.d(T.MAIN, "GOOGLE SIGNUP: onSocialChanged - google login success");

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
@@ -269,7 +269,7 @@ public class SignupGoogleFragment extends GoogleFragment {
             AppLog.d(T.MAIN, "GOOGLE SIGNUP: onSocialChanged - 2fa required");
             mAnalyticsListener.trackSignupSocialToLogin();
             mLoginListener.needs2faSocial(mGoogleEmail, event.userId, event.nonceAuthenticator, event.nonceBackup,
-                    event.nonceSms);
+                    event.nonceSms, event.nonceWebauthn);
             finishFlow();
         } else {
             AppLog.d(T.MAIN, "GOOGLE SIGNUP: onSocialChanged - google login success");

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
@@ -269,7 +269,7 @@ public class SignupGoogleFragment extends GoogleFragment {
             AppLog.d(T.MAIN, "GOOGLE SIGNUP: onSocialChanged - 2fa required");
             mAnalyticsListener.trackSignupSocialToLogin();
             mLoginListener.needs2faSocial(mGoogleEmail, event.userId, event.nonceAuthenticator, event.nonceBackup,
-                    event.nonceSms, event.twoStepTypes);
+                    event.nonceSms, event.nonceWebauthn, event.twoStepTypes);
             finishFlow();
         } else {
             AppLog.d(T.MAIN, "GOOGLE SIGNUP: onSocialChanged - google login success");

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     // libs
     wordpressLintVersion = '2.0.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = '2894-d54315df2b1c43541ec63b0678e3ea5fdde5c551'
+    wordpressFluxCVersion = 'trunk-4b892d8c87bd88dd1b62a0c3f3eb2a81ee6a430a'
 
     // main
     androidxAppCompatVersion = '1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     // libs
     wordpressLintVersion = '2.0.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = '2874-5550a55ea12d374fd42749a7f515f8e6bc934087'
+    wordpressFluxCVersion = '2894-8d6f59a4c762a0bd6290563ebc69f18760e69b52'
 
     // main
     androidxAppCompatVersion = '1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     // libs
     wordpressLintVersion = '2.0.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = '2894-8d6f59a4c762a0bd6290563ebc69f18760e69b52'
+    wordpressFluxCVersion = '2894-4dafa51beba01c8ba49912a1a3a3b7ffbb50ed76'
 
     // main
     androidxAppCompatVersion = '1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     // libs
     wordpressLintVersion = '2.0.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = '2894-b6465ba40019058ddac221b5f5caf830692b2c8e'
+    wordpressFluxCVersion = '2894-a132f64ae82c08048bc1456c9b28a31a6f41920c'
 
     // main
     androidxAppCompatVersion = '1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     // libs
     wordpressLintVersion = '2.0.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = '2894-a132f64ae82c08048bc1456c9b28a31a6f41920c'
+    wordpressFluxCVersion = '2894-d54315df2b1c43541ec63b0678e3ea5fdde5c551'
 
     // main
     androidxAppCompatVersion = '1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     // libs
     wordpressLintVersion = '2.0.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = '2874-5550a55ea12d374fd42749a7f515f8e6bc934087'
+    wordpressFluxCVersion = '2894-b6465ba40019058ddac221b5f5caf830692b2c8e'
 
     // main
     androidxAppCompatVersion = '1.0.2'


### PR DESCRIPTION
Summary
==========
Following the previous changes introduced in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2874, this PR simply adds the `webauthn` nonce to the Social login payload to be used in the WPLogin library. For our own advantage, the Social login endpoint already returns the same response structure from the `/wp-login.php?action=login-endpoint`, so the `Login2faFragment` required very little adaptation to work with this flow seamlessly.

How to Test
==========
1. Introduce this WPLogin version to your client app.
2. Login with a Google account associated with WordPress.com using the `Login with Google` button during the login flow. (make sure this same account also has a Security key configured for your device)
3. Verify that the 2FA view is opened and the `use a security key` option is enabled.
4. Continue the usual Security key flow and make sure everything works as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

