### PR TITLE
Update FluxC to tagged version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     // libs
     wordpressLintVersion = '2.0.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = 'trunk-4b892d8c87bd88dd1b62a0c3f3eb2a81ee6a430a'
+    wordpressFluxCVersion = '2.57.0'
 
     // main
     androidxAppCompatVersion = '1.0.2'


### PR DESCRIPTION
This PR updates FluxC from a commit hash to a tagged version: `2.57.0` This is part of the WP/JPAndroid 23.8 code freeze steps. 