### PR TITLE
Add Credential Manager dependency

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -21,6 +21,15 @@ repositories {
 }
 
 android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlin {
+        jvmToolchain(17)
+    }
+
     namespace "org.wordpress.android.login"
 
     compileSdkVersion rootProject.compileSdkVersion

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -73,8 +73,8 @@ dependencies {
 
     implementation "com.google.android.gms:play-services-fido:$fidoVersion"
 
-    implementation "androidx.credentials:credentials:1.2.0"
-    implementation "androidx.credentials:credentials-play-services-auth:1.2.0"
+    implementation "androidx.credentials:credentials:$credentialManagerVersion"
+    implementation "androidx.credentials:credentials-play-services-auth:$credentialManagerVersion"
 
     // Dagger
     implementation "com.google.dagger:dagger:$daggerVersion"

--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -64,6 +64,9 @@ dependencies {
 
     implementation "com.google.android.gms:play-services-fido:$fidoVersion"
 
+    implementation "androidx.credentials:credentials:1.2.0"
+    implementation "androidx.credentials:credentials-play-services-auth:1.2.0"
+
     // Dagger
     implementation "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -76,8 +76,8 @@ class SignupConfirmationFragment : Fragment() {
             mPhotoUrl = it.getString(ARG_SOCIAL_PHOTO_URL)
             mService = it.getString(ARG_SOCIAL_SERVICE)
         }
-        //TODO: Migrate this to current SDK requirement, this one is deprecated
-        //setHasOptionsMenu(true)
+        // TODO: Migrate this to current SDK requirement, this one is deprecated
+        // setHasOptionsMenu(true)
     }
 
     override fun onCreateView(

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -76,7 +76,8 @@ class SignupConfirmationFragment : Fragment() {
             mPhotoUrl = it.getString(ARG_SOCIAL_PHOTO_URL)
             mService = it.getString(ARG_SOCIAL_SERVICE)
         }
-        setHasOptionsMenu(true)
+        //TODO: Migrate this to current SDK requirement, this one is deprecated
+        //setHasOptionsMenu(true)
     }
 
     override fun onCreateView(

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -13,13 +13,15 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import dagger.android.support.AndroidSupportInjection
 import org.wordpress.android.login.util.AvatarHelper.AvatarRequestListener
 import org.wordpress.android.login.util.AvatarHelper.loadAvatarFromUrl
 import javax.inject.Inject
 
-class SignupConfirmationFragment : Fragment() {
+class SignupConfirmationFragment : Fragment(), MenuProvider {
     private var mLoginListener: LoginListener? = null
 
     private var mEmail: String? = null
@@ -76,8 +78,8 @@ class SignupConfirmationFragment : Fragment() {
             mPhotoUrl = it.getString(ARG_SOCIAL_PHOTO_URL)
             mService = it.getString(ARG_SOCIAL_SERVICE)
         }
-        // TODO: Migrate this to current SDK requirement, this one is deprecated
-        // setHasOptionsMenu(true)
+
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
     override fun onCreateView(
@@ -130,11 +132,11 @@ class SignupConfirmationFragment : Fragment() {
         mLoginListener = null
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_login, menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.help) {
             mAnalyticsListener.trackShowHelpClick()
             if (mLoginListener != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ ext {
     materialVersion = '1.2.1'
     playServicesAuthVersion = '18.1.0'
     fidoVersion = '20.1.0'
+    credentialManagerVersion = '1.2.0'
 
     // test
     androidxArchCoreVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -18,14 +18,14 @@ ext {
     wordpressFluxCVersion = '2.57.0'
 
     // main
-    androidxAppCompatVersion = '1.0.2'
-    androidxCoreVersion = '1.3.2'
+    androidxAppCompatVersion = '1.6.1'
+    androidxCoreVersion = '1.12.0'
     androidxConstraintLayoutVersion = '2.0.4'
     androidxGlidLayoutVersion = '1.0.0'
     androidxLegacySupportV13Version = '1.0.0'
     androidxMediaVersion = '1.2.1'
     androidxVectorDrawableAnimatedVersion = '1.1.0'
-    daggerVersion = '2.42'
+    daggerVersion = '2.47'
     glideVersion = '4.12.0'
     javaxAnnotationVersion = '10.0-b28'
     materialVersion = '1.2.1'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.6.10'
+    gradle.ext.kotlinVersion = '1.8.0'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.automatticPublishToS3Version = '0.8.0'
 


### PR DESCRIPTION
Summary
==========
Add the Credential Manager dependency to the WordPress Login library. Since the Credential Manager is an API 34 library, some library bumps were required to avoid dependency conflicts. Which required some code adjustments due to build errors introduced by those bumps.

How to Test
==========
1. Integrate this version with Woo and make sure it's still possible to login with no issues.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.