### PR TITLE
[Fix] Update targetSdk to 34 from 33.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 ext {
     minSdkVersion = 24
     compileSdkVersion = 34
-    targetSdkVersion = 33
+    targetSdkVersion = 34
 }
 
 ext {


### PR DESCRIPTION
Update targetSdkVersion from 33 to 34 (Android 14)

Part of https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/issues/130

### Test

- [ ] Checkout this branch
- [ ] Use this branch through WP (uncomment localLoginFlowPath in local-builds.gradle)
- [ ]  Log out if already logged in
- [ ] Try out Login flow
- [ ] Ensure, no issues or crashes