### PR TITLE
Fix Smart Lock Login with 2FA issue

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
+import org.wordpress.android.fluxc.store.AccountStore.OnTwoFactorAuthStarted;
 import org.wordpress.android.fluxc.store.SiteStore.OnProfileFetched;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
@@ -504,13 +505,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
             case INVALID_TOKEN:
             case AUTHORIZATION_REQUIRED:
             case NEEDS_2FA:
-                if (mIsWpcom) {
-                    if (mLoginListener != null) {
-                        mLoginListener.needs2fa(mRequestedUsername, mRequestedPassword);
-                    }
-                } else {
-                    showError("2FA not supported for self-hosted sites. Please use an app-password.");
-                }
+                handle2fa();
                 break;
             default:
                 AppLog.e(T.NUX, "Server response: " + errorMessage);
@@ -521,7 +516,25 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
         }
     }
 
+    private void handle2fa() {
+        if (mIsWpcom) {
+            if (mLoginListener != null) {
+                mLoginListener.needs2fa(mRequestedUsername, mRequestedPassword);
+            }
+        } else {
+            showError("2FA not supported for self-hosted sites. Please use an app-password.");
+        }
+    }
+
     // OnChanged events
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onTwoFactorAuthStarted(OnTwoFactorAuthStarted event) {
+        mLoginStarted = false;
+        handle2fa();
+        endProgress();
+    }
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)


### PR DESCRIPTION
2FA case was handled as an auth error in `LoginUsernamePasswordFragment`. But FluxC is dispatching `OnTwoFactorAuthStarted` event instead of an auth error. I subscribed FluxC event to handle the 2FA case in `LoginUsernamePasswordFragment.`

Test this PR on [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android)'s trunk.

**Before video**
It is stuck at loading.

[before-video.webm](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/assets/2471769/1f84c446-7463-4088-a790-e939076f2e75)

**To Test:**
Can be tested on https://github.com/wordpress-mobile/WordPress-Android/pull/20102
1. Have a WP account with 2FA enabled.
2. The account should be saved on your Smart Lock Login.
3. Log in to JP with the Smart Lock Login option.
4. Verify it requests the verification code and enter the verification code.
5. Verify it logs in successfully.