### PR TITLE
Handle passkey errors

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -624,6 +624,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
                 },
                 error -> {
                     handleWebauthnError();
+                    getParentFragmentManager().popBackStack();
                     return null;
                 }
         );

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -619,14 +619,11 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
                 requireContext(),
                 passkeyRequestData,
                 result -> {
-                    mDispatcher.dispatch(
-                            AuthenticationActionBuilder.newFinishSecurityKeyChallengeAction(
-                                    result));
+                    mDispatcher.dispatch(result);
                     return null;
                 },
                 error -> {
                     handleWebauthnError();
-                    getParentFragmentManager().popBackStack();
                     return null;
                 }
         );

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -625,6 +625,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
                 error -> {
                     handleWebauthnError();
                     mLoginListener.securityKey2FAFailed();
+                    getParentFragmentManager().popBackStack();
                     return null;
                 }
         );

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -626,6 +626,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
                 },
                 error -> {
                     handleWebauthnError();
+                    getParentFragmentManager().popBackStack();
                     return null;
                 }
         );

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -624,8 +624,6 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
                 },
                 error -> {
                     handleWebauthnError();
-                    mLoginListener.securityKey2FAFailed();
-                    getParentFragmentManager().popBackStack();
                     return null;
                 }
         );
@@ -647,6 +645,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         String errorMessage = getString(R.string.login_error_security_key);
         endProgress();
         handleAuthError(AuthenticationErrorType.WEBAUTHN_FAILED, errorMessage);
+        getParentFragmentManager().popBackStack();
     }
 
     @NonNull private ArrayList<SupportedAuthTypes> handleSupportedAuthTypesParameter(

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -624,7 +624,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
                 },
                 error -> {
                     handleWebauthnError();
-                    getParentFragmentManager().popBackStack();
+                    mLoginListener.securityKey2FAFailed();
                     return null;
                 }
         );

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -606,6 +606,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         if (event.isError()) {
             endProgress();
             handleAuthError(event.error.type, getString(R.string.login_error_security_key));
+            getParentFragmentManager().popBackStack();
             return;
         }
 
@@ -635,6 +636,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         if (event.isError()) {
             endProgress();
             handleAuthError(event.error.type, getString(R.string.login_error_security_key));
+            getParentFragmentManager().popBackStack();
             return;
         }
         mAnalyticsListener.trackLoginSecurityKeySuccess();

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -604,9 +604,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onWebauthnChallengeReceived(WebauthnChallengeReceived event) {
         if (event.isError()) {
-            endProgress();
-            handleAuthError(event.error.type, getString(R.string.login_error_security_key));
-            getParentFragmentManager().popBackStack();
+            handleWebauthnError(event.error.type, getString(R.string.login_error_security_key));
             return;
         }
 
@@ -624,7 +622,8 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
                     return null;
                 },
                 error -> {
-                    handleWebauthnError();
+                    String errorMessage = getString(R.string.login_error_security_key);
+                    handleWebauthnError(AuthenticationErrorType.WEBAUTHN_FAILED, errorMessage);
                     return null;
                 }
         );
@@ -634,19 +633,16 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSecurityKeyCheckFinished(WebauthnPasskeyAuthenticated event) {
         if (event.isError()) {
-            endProgress();
-            handleAuthError(event.error.type, getString(R.string.login_error_security_key));
-            getParentFragmentManager().popBackStack();
+            handleWebauthnError(event.error.type, getString(R.string.login_error_security_key));
             return;
         }
         mAnalyticsListener.trackLoginSecurityKeySuccess();
         doFinishLogin();
     }
 
-    private void handleWebauthnError() {
-        String errorMessage = getString(R.string.login_error_security_key);
+    private void handleWebauthnError(AuthenticationErrorType errorType, String errorMessage) {
         endProgress();
-        handleAuthError(AuthenticationErrorType.WEBAUTHN_FAILED, errorMessage);
+        handleAuthError(errorType, errorMessage);
         getParentFragmentManager().popBackStack();
     }
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -92,6 +92,4 @@ public interface LoginListener {
     void showSignupMagicLink(String email);
     void showSignupSocial(String email, String displayName, String idToken, String photoUrl, String service);
     void showSignupToLoginMessage();
-
-    void securityKey2FAFailed();
 }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -92,4 +92,6 @@ public interface LoginListener {
     void showSignupMagicLink(String email);
     void showSignupSocial(String email, String displayName, String idToken, String photoUrl, String service);
     void showSignupToLoginMessage();
+
+    void securityKey2FAFailed();
 }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/webauthn/PasskeyRequest.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/webauthn/PasskeyRequest.kt
@@ -7,20 +7,21 @@ import androidx.credentials.CredentialManager
 import androidx.credentials.CredentialManagerCallback
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetCredentialResponse
-import androidx.credentials.GetPasswordOption
 import androidx.credentials.GetPublicKeyCredentialOption
 import androidx.credentials.PublicKeyCredential
 import androidx.credentials.exceptions.GetCredentialException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
 import org.wordpress.android.fluxc.store.AccountStore.FinishWebauthnChallengePayload
 import java.util.concurrent.Executors
 
 class PasskeyRequest private constructor(
     context: Context,
     requestData: PasskeyRequestData,
-    onSuccess: (FinishWebauthnChallengePayload) -> Unit,
+    onSuccess: (Action<FinishWebauthnChallengePayload>) -> Unit,
     onFailure: (Throwable) -> Unit
 ) {
     init {
@@ -41,7 +42,9 @@ class PasskeyRequest private constructor(
                     mUserId = requestData.userId
                     mTwoStepNonce = requestData.twoStepNonce
                     mClientData = result.toJson().orEmpty()
-                }.let { onSuccess(it) }
+                }.let {
+                    AuthenticationActionBuilder.newFinishSecurityKeyChallengeAction(it)
+                }.let(onSuccess)
             }
         }
 
@@ -82,7 +85,7 @@ class PasskeyRequest private constructor(
         fun create(
             context: Context,
             requestData: PasskeyRequestData,
-            onSuccess: (FinishWebauthnChallengePayload) -> Unit,
+            onSuccess: (Action<FinishWebauthnChallengePayload>) -> Unit,
             onFailure: (Throwable) -> Unit
         ) {
             PasskeyRequest(context, requestData, onSuccess, onFailure)


### PR DESCRIPTION
Summary
==========
When the Passkey flow fails, it's not possible anymore to try a new key fetching due to how the webauthn nonce works. But since any Passkey failure keeps the user in the 2FA screen, it may mislead that they can hit the `use a security key` button to try again. 

To address this scenario, this PR implements any Passkey error scenario and moves the user back to the Password screen, where it's actually possible to restart the authentication flow and try once again.

Screen capture
==========
https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/assets/5920403/3c8e1322-718d-43c5-9b98-3b5107bef91e

How to Test
==========
1. Open the [Woo app configured with this PR](https://github.com/woocommerce/woocommerce-android/pull/10647) and start the login flow with the same WordPress.com account you used to create the Security Key.
2. Once you hit the 2FA screen, make sure the `Use security key` button appears and click on it.
3. Make sure the Credential Manager opens up with a selectable Passkey, instead of selecting it a Passkey, **HIT THE BACK BUTTON TO LEAVE THE CREDENTIAL MANAGER WITHOUT A PASSKEY SELECTION**.
4. This should trigger a Passkey failure scenario, make sure the login flow moves back to the Password selection view, with the Password pre-filled.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.