### PR TITLE
Move `addMenuProvider` from `onCreate` to `onViewCreated`

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -78,8 +78,6 @@ class SignupConfirmationFragment : Fragment(), MenuProvider {
             mPhotoUrl = it.getString(ARG_SOCIAL_PHOTO_URL)
             mService = it.getString(ARG_SOCIAL_SERVICE)
         }
-
-        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
     override fun onCreateView(
@@ -118,6 +116,8 @@ class SignupConfirmationFragment : Fragment(), MenuProvider {
         if (savedInstanceState == null) {
             mAnalyticsListener.trackSocialSignupConfirmationViewed()
         }
+
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
     @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")


### PR DESCRIPTION
Summary
==========
Fix issue https://github.com/wordpress-mobile/WordPress-Android/issues/20221 by adjusting the point where the menu provider added to the `SignupConfirmationFragment` view.


How to Test
==========
1. Import this PR to the WordPress or Woo app by using the `142-48e7fc1f82f011c246e23ac4b4a0c9195b3d7c21` version hash.
2. Start the signup flow using an email account not registered on WordPress.com.
3. Verify that during the Signup process, when landing in the view with the `We’ll use this email address to create your new WordPress.com account` (the `SignupConfirmationFragment`), the view loads as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.