### PR TITLE
Update WordPress-Lint-Android version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
 
 ext {
     // libs
-    wordpressLintVersion = '2.0.0'
+    wordpressLintVersion = '2.1.0'
     wordpressUtilsVersion = '3.5.0'
     wordpressFluxCVersion = 'trunk-ed60798b4d96ec19863c74b0f525e2e20f4525db'
 


### PR DESCRIPTION
### Description

This PR bumps the version of WordPress-Lint-Android to [`2.1.0`](https://github.com/wordpress-mobile/WordPress-Lint-Android/releases/tag/2.1.0), which [fixes an issue](https://github.com/wordpress-mobile/WordPress-Lint-Android/pull/19) with false positives when warning about missing null annotations for enums.

#### Test

In Android Studio, navigate to a Java file that has an enum declaration. It should no longer warn about missing null annotations for the enum.