### PR TITLE
Fix carrot visibility for input when validation throws error

### DIFF
--- a/WordPressLoginFlow/src/main/res/layout/login_input_row.xml
+++ b/WordPressLoginFlow/src/main/res/layout/login_input_row.xml
@@ -19,6 +19,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:drawablePadding="10dp"
+            android:textCursorDrawable="@null"
             tools:hint="@string/email_address" />
     </com.google.android.material.textfield.TextInputLayout>
 </RelativeLayout>


### PR DESCRIPTION
Fix for the issue https://github.com/wordpress-mobile/WordPress-Android/issues/19561

The issue seemed to be related to the color of the cursor. Solution applied from https://stackoverflow.com/questions/7238450/set-edittext-cursor-color

More details: https://github.com/wordpress-mobile/WordPress-Android/issues/19561#issuecomment-2165868432

![image](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/assets/60236665/c90433b7-c358-4bca-bcaa-4c2a70418f9e)

Kuddos to @staskus for incredible help at WCEU!
