### PR TITLE
Override onTimeout() in LoginWpcomService

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
@@ -279,6 +279,12 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
     }
 
     @Override
+    public void onTimeout(int startId) {
+        super.onTimeout(startId);
+        setState(LoginStep.FAILURE); // This will cal stopSelf()
+    }
+
+    @Override
     public int onStartCommand(@Nullable Intent intent, int flags, int startId) {
         if (intent == null) {
             return START_NOT_STICKY;


### PR DESCRIPTION
We need to specify a foreground service type for `LoginWpcomService` in consumer apps. The ideal type is the short service. 

> ...it's considered best practice to implement the `Service.onTimeout()` callback.
. - https://developer.android.com/about/versions/14/changes/fgs-types-required#short-service

According to the documentation, we need to implement `onTimeout()`. This PR overrides 'onTimeout()` and sets a failure message that concludes with calling `stopSelf()`.

This can be tested via https://github.com/woocommerce/woocommerce-android/pull/11970.