### PR TITLE
Fixes for the SMS 2FA

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -132,7 +132,6 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
                                                String userId, String webauthnNonce,
                                                String authenticatorNonce, String backupNonce,
                                                String smsNonce, List<String> authTypes) {
-        boolean supportsWebauthn = webauthnNonce != null && !webauthnNonce.isEmpty();
         Login2FaFragment fragment = new Login2FaFragment();
         Bundle args = new Bundle();
         args.putString(ARG_EMAIL_ADDRESS, emailAddress);

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.login;
 
+import static android.content.Context.CLIPBOARD_SERVICE;
+
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.os.Bundle;
@@ -52,8 +54,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static android.content.Context.CLIPBOARD_SERVICE;
 
 import dagger.android.support.AndroidSupportInjection;
 
@@ -208,7 +208,9 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         // restrict the allowed input chars to just numbers
         m2FaInput.getEditText().setKeyListener(DigitsKeyListener.getInstance("0123456789"));
 
-        boolean isSmsEnabled = mSupportedAuthTypes.contains(SupportedAuthTypes.PUSH);
+        // If we didn't get a list of supported auth types, then the flow is not using webauthn,
+        // We should treat it as if SMS is enabled for the user
+        boolean isSmsEnabled = mSupportedAuthTypes.isEmpty() || mSupportedAuthTypes.contains(SupportedAuthTypes.PUSH);
         mOtpButton = rootView.findViewById(R.id.login_otp_button);
         mOtpButton.setVisibility(isSmsEnabled ? View.VISIBLE : View.GONE);
         mOtpButton.setText(mSentSmsCode ? R.string.login_text_otp_another : R.string.login_text_otp);

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
     // libs
     wordpressLintVersion = '2.1.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = 'trunk-ed60798b4d96ec19863c74b0f525e2e20f4525db'
+    wordpressFluxCVersion = '3079-0f189a0307b77a315df19c38292f8d5a86e3f0d5'
     gravatarSdkVersion = '0.2.0'
 
     // main

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://a8c-libs.s3.amazonaws.com/android/jcenter-mirror"
+            content {
+                includeVersion "com.android.volley", "volley", "1.1.1"
+            }
+        }
     }
 
     if (tasks.findByPath('checkstyle') == null) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
     // libs
     wordpressLintVersion = '2.1.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = '3079-0f189a0307b77a315df19c38292f8d5a86e3f0d5'
+    wordpressFluxCVersion = 'trunk-863f213e0e3a7a4322032e8e8c57a99f77bb48ec'
     gravatarSdkVersion = '0.2.0'
 
     // main


### PR DESCRIPTION
This PR aligns with the changes of the FluxC [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3079).
With the change to revert to the `/token` endpoint, we won't be getting a list of supported authentication types during the login, so this PR updates the logic of the visibility of the "Send SMS" button to account for this.

### Testing
Check the PR https://github.com/woocommerce/woocommerce-android/pull/12319