### PR TITLE
[Woo] Allow signing in to WPCom black-flagged websites using site credentials

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/ConnectSiteInfoResult.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/ConnectSiteInfoResult.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.login
 
 data class ConnectSiteInfoResult @JvmOverloads constructor(
     val url: String,
-    val urlAfterRedirects: String,
+    val urlAfterRedirects: String?,
     val hasJetpack: Boolean,
     /**
      * Whether the site is suspended on WordPress.com and can't be connected using Jetpack

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/ConnectSiteInfoResult.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/ConnectSiteInfoResult.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.login
+
+data class ConnectSiteInfoResult @JvmOverloads constructor(
+    val url: String,
+    val urlAfterRedirects: String,
+    val hasJetpack: Boolean,
+    /**
+     * Whether the site is suspended on WordPress.com and can't be connected using Jetpack
+     */
+    val isWPComSuspended: Boolean = false,
+)

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -61,7 +61,11 @@ public interface LoginListener {
     // Login Site Address input callbacks
     void alreadyLoggedInWpcom(ArrayList<Integer> oldSitesIds);
     void gotWpcomSiteInfo(String siteAddress);
-    void gotConnectedSiteInfo(@NonNull String siteAddress, @Nullable String redirectUrl, boolean hasJetpack);
+    default void gotConnectSiteInfo(@NonNull ConnectSiteInfoResult result) {
+        gotConnectedSiteInfo(result.getUrl(), result.getUrlAfterRedirects(), result.getHasJetpack());
+    }
+
+    default void gotConnectedSiteInfo(@NonNull String siteAddress, @Nullable String redirectUrl, boolean hasJetpack) { }
     void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress);
     void handleSslCertificateError(MemorizingTrustManager memorizingTrustManager, SelfSignedSSLCallback callback);
     void helpSiteAddress(String url);

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -397,7 +397,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
                 mLoginListener.gotConnectSiteInfo(
                         new ConnectSiteInfoResult(
                                 mRequestedSiteAddress,
-                                mRequestedSiteAddress,
+                                null,
                                 mConnectSiteInfoCalculatedHasJetpack,
                                 true
                         )

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -340,17 +340,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         // hold the URL in a variable to use below otherwise it gets cleared up by endProgress
         String inputSiteAddress = mRequestedSiteAddress;
         endProgress();
-        if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
-            mLoginListener.gotConnectSiteInfo(
-                    new ConnectSiteInfoResult(
-                            mConnectSiteInfoUrl,
-                            mConnectSiteInfoUrlRedirect,
-                            mConnectSiteInfoCalculatedHasJetpack
-                    )
-            );
-        } else {
-            mLoginListener.gotXmlRpcEndpoint(inputSiteAddress, endpointAddress);
-        }
+        mLoginListener.gotXmlRpcEndpoint(inputSiteAddress, endpointAddress);
     }
 
     private void askForHttpAuthCredentials(@NonNull final String url, int messageId) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
     // libs
     wordpressLintVersion = '2.1.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = 'trunk-863f213e0e3a7a4322032e8e8c57a99f77bb48ec'
+    wordpressFluxCVersion = '3107-f51c7f6c7ce02a207df0b45e074941225850b6ae'
     gravatarSdkVersion = '0.2.0'
 
     // main

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
     // libs
     wordpressLintVersion = '2.1.0'
     wordpressUtilsVersion = '3.5.0'
-    wordpressFluxCVersion = '3107-f51c7f6c7ce02a207df0b45e074941225850b6ae'
+    wordpressFluxCVersion = 'trunk-5dfbbc993d2472f6aad2b9f357021506ecfe7152'
     gravatarSdkVersion = '0.2.0'
 
     // main


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/12779

Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3107

This PR updates the login flow for Woo to allow signing in to WordPress.com black-flagged websites, those websites will be treated as not having Jetpack, and will then be directed to the site credentials login flow.

### Testing
For testing, please check https://github.com/woocommerce/woocommerce-android/pull/12780