### PR TITLE
Use Magic Link for WordPress.com suspicious [Part 2]

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.kt
@@ -59,6 +59,7 @@ interface LoginAnalyticsListener {
     fun trackSubmitClicked()
     fun trackRequestMagicLinkClick()
     fun trackLoginWithPasswordClick()
+    fun trackLoginWithWpComUsernamePasswordClick()
     fun trackShowHelpClick()
     fun trackDismissDialog()
     fun trackSelectEmailField()

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -588,7 +588,10 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                     // combination. Ask them to use Magic Link instead.
                     mAnalyticsListener.trackFailure("Login with username required");
                     if (mLoginListener != null) {
-                        mLoginListener.useMagicLinkInstead(email, false, false);
+                        mLoginListener.useMagicLinkInstead(email,
+                                false,
+                                false,
+                                MagicLinkFallbackButton.UsernameAndPassword);
                     }
                     break;
                 case GENERIC_ERROR:

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -193,12 +193,10 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
 
         final Button magicLinkButton = rootView.findViewById(R.id.login_get_email_link);
         magicLinkButton.setVisibility(mAllowMagicLink ? View.VISIBLE : View.GONE);
-        magicLinkButton.setOnClickListener(new OnClickListener() {
-            @Override public void onClick(View v) {
-                if (mLoginListener != null) {
-                    mAnalyticsListener.trackRequestMagicLinkClick();
-                    mLoginListener.useMagicLinkInstead(mEmailAddress, mVerifyMagicLinkEmail, true);
-                }
+        magicLinkButton.setOnClickListener(v -> {
+            if (mLoginListener != null) {
+                mAnalyticsListener.trackRequestMagicLinkClick();
+                mLoginListener.useMagicLinkInstead(mEmailAddress, mVerifyMagicLinkEmail, true, MagicLinkFallbackButton.None);
             }
         });
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -196,7 +196,8 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
         magicLinkButton.setOnClickListener(v -> {
             if (mLoginListener != null) {
                 mAnalyticsListener.trackRequestMagicLinkClick();
-                mLoginListener.useMagicLinkInstead(mEmailAddress, mVerifyMagicLinkEmail, true, MagicLinkFallbackButton.None);
+                mLoginListener.useMagicLinkInstead(mEmailAddress, mVerifyMagicLinkEmail,
+                        true, MagicLinkFallbackButton.None);
             }
         });
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -47,7 +47,8 @@ public interface LoginListener {
 
     // Login email password callbacks
     void forgotPassword(String url);
-    void useMagicLinkInstead(String email, boolean verifyEmail, boolean requestAtStart, MagicLinkFallbackButton fallbackButton);
+    void useMagicLinkInstead(String email, boolean verifyEmail,
+                             boolean requestAtStart, MagicLinkFallbackButton fallbackButton);
     void needs2fa(String email, String password);
     void needs2fa(String email, String password, String userId, String webauthnNonce,
                   String nonceAuthenticator, String nonceBackup, String noncePush,

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -47,7 +47,7 @@ public interface LoginListener {
 
     // Login email password callbacks
     void forgotPassword(String url);
-    void useMagicLinkInstead(String email, boolean verifyEmail, boolean requestAtStart);
+    void useMagicLinkInstead(String email, boolean verifyEmail, boolean requestAtStart, MagicLinkFallbackButton fallbackButton);
     void needs2fa(String email, String password);
     void needs2fa(String email, String password, String userId, String webauthnNonce,
                   String nonceAuthenticator, String nonceBackup, String noncePush,

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -37,7 +37,7 @@ public interface LoginListener {
     void onTermsOfServiceClicked();
 
     // Login Request Magic Link callbacks
-    void showMagicLinkSentScreen(String email, boolean allowPassword);
+    void showMagicLinkSentScreen(String email, MagicLinkFallbackButton fallbackButton);
     void usePasswordInstead(String email);
     void helpMagicLinkRequest(String email);
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -372,7 +372,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
                     fragmentManager.popBackStack();
                 }
             }
-            mLoginListener.showMagicLinkSentScreen(mEmail, mFallbackButton == MagicLinkFallbackButton.Password);
+            mLoginListener.showMagicLinkSentScreen(mEmail, mFallbackButton);
         }
     }
 }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -52,7 +52,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     private static final String ARG_IS_JETPACK_CONNECT = "ARG_IS_JETPACK_CONNECT";
     private static final String ARG_JETPACK_CONNECT_SOURCE = "ARG_JETPACK_CONNECT_SOURCE";
     private static final String ARG_VERIFY_MAGIC_LINK_EMAIL = "ARG_VERIFY_MAGIC_LINK_EMAIL";
-    private static final String ARG_ALLOW_PASSWORD = "ARG_ALLOW_PASSWORD";
+    private static final String ARG_FALLBACK_BUTTON = "ARG_FALLBACK_BUTTON";
     private static final String ARG_FORCE_REQUEST_AT_START = "ARG_FORCE_REQUEST_AT_START";
 
     private static final String ERROR_KEY = "error";
@@ -70,7 +70,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     private boolean mInProgress;
     private boolean mIsJetpackConnect;
     private boolean mVerifyMagicLinkEmail;
-    private boolean mAllowPassword;
+    private MagicLinkFallbackButton mFallbackButton;
     private boolean mForceRequestAtStart;
 
     @Inject protected Dispatcher mDispatcher;
@@ -80,12 +80,12 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     public static LoginMagicLinkRequestFragment newInstance(String email, AuthEmailPayloadScheme scheme,
                                                             boolean isJetpackConnect, String jetpackConnectSource,
                                                             boolean verifyEmail) {
-        return newInstance(email, scheme, isJetpackConnect, jetpackConnectSource, verifyEmail, true, false);
+        return newInstance(email, scheme, isJetpackConnect, jetpackConnectSource, verifyEmail, MagicLinkFallbackButton.Password, false);
     }
 
     public static LoginMagicLinkRequestFragment newInstance(String email, AuthEmailPayloadScheme scheme,
                                                             boolean isJetpackConnect, String jetpackConnectSource,
-                                                            boolean verifyEmail, boolean allowPassword,
+                                                            boolean verifyEmail, MagicLinkFallbackButton fallbackButton,
                                                             boolean forceRequestAtStart) {
         LoginMagicLinkRequestFragment fragment = new LoginMagicLinkRequestFragment();
         Bundle args = new Bundle();
@@ -94,7 +94,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
         args.putBoolean(ARG_IS_JETPACK_CONNECT, isJetpackConnect);
         args.putString(ARG_JETPACK_CONNECT_SOURCE, jetpackConnectSource);
         args.putBoolean(ARG_VERIFY_MAGIC_LINK_EMAIL, verifyEmail);
-        args.putBoolean(ARG_ALLOW_PASSWORD, allowPassword);
+        args.putSerializable(ARG_FALLBACK_BUTTON, fallbackButton);
         args.putBoolean(ARG_FORCE_REQUEST_AT_START, forceRequestAtStart);
         fragment.setArguments(args);
         return fragment;
@@ -121,7 +121,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
             mIsJetpackConnect = getArguments().getBoolean(ARG_IS_JETPACK_CONNECT);
             mJetpackConnectSource = getArguments().getString(ARG_JETPACK_CONNECT_SOURCE);
             mVerifyMagicLinkEmail = getArguments().getBoolean(ARG_VERIFY_MAGIC_LINK_EMAIL);
-            mAllowPassword = getArguments().getBoolean(ARG_ALLOW_PASSWORD);
+            mFallbackButton = (MagicLinkFallbackButton) getArguments().getSerializable(ARG_FALLBACK_BUTTON);
             mForceRequestAtStart = getArguments().getBoolean(ARG_FORCE_REQUEST_AT_START);
         }
 
@@ -132,23 +132,30 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.login_magic_link_request_screen, container, false);
         mRequestMagicLinkButton = view.findViewById(R.id.login_request_magic_link);
-        mRequestMagicLinkButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                mAnalyticsListener.trackRequestMagicLinkClick();
-                dispatchMagicLinkRequest();
-            }
+        mRequestMagicLinkButton.setOnClickListener(v -> {
+            mAnalyticsListener.trackRequestMagicLinkClick();
+            dispatchMagicLinkRequest();
         });
 
-        final Button passwordButton = view.findViewById(R.id.login_enter_password);
-        passwordButton.setVisibility(mAllowPassword ? View.VISIBLE : View.GONE);
-        passwordButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                mAnalyticsListener.trackLoginWithPasswordClick();
-                if (mLoginListener != null) {
-                    mLoginListener.usePasswordInstead(mEmail);
+        final Button fallbackButtonView = view.findViewById(R.id.login_magic_link_fallback_button);
+        fallbackButtonView.setVisibility(mFallbackButton == MagicLinkFallbackButton.None ? View.GONE : View.VISIBLE);
+        fallbackButtonView.setText(mFallbackButton == MagicLinkFallbackButton.UsernameAndPassword ?
+                R.string.login_use_wpcom_username_instead :
+                R.string.or_type_your_password);
+        fallbackButtonView.setOnClickListener(v -> {
+            switch (mFallbackButton) {
+                case Password -> {
+                    mAnalyticsListener.trackLoginWithPasswordClick();
+                    if (mLoginListener != null) {
+                        mLoginListener.usePasswordInstead(mEmail);
+                    }
                 }
+                case UsernameAndPassword -> {
+                    if (mLoginListener != null) {
+                        mLoginListener.loginViaWpcomUsernameInstead();
+                    }
+                }
+                case None -> throw new IllegalStateException("Button should not be visible");
             }
         });
 
@@ -365,7 +372,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
                     fragmentManager.popBackStack();
                 }
             }
-            mLoginListener.showMagicLinkSentScreen(mEmail, mAllowPassword);
+            mLoginListener.showMagicLinkSentScreen(mEmail, mFallbackButton == MagicLinkFallbackButton.Password);
         }
     }
 }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -80,7 +80,8 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     public static LoginMagicLinkRequestFragment newInstance(String email, AuthEmailPayloadScheme scheme,
                                                             boolean isJetpackConnect, String jetpackConnectSource,
                                                             boolean verifyEmail) {
-        return newInstance(email, scheme, isJetpackConnect, jetpackConnectSource, verifyEmail, MagicLinkFallbackButton.Password, false);
+        return newInstance(email, scheme, isJetpackConnect, jetpackConnectSource,
+                verifyEmail, MagicLinkFallbackButton.Password, false);
     }
 
     public static LoginMagicLinkRequestFragment newInstance(String email, AuthEmailPayloadScheme scheme,
@@ -139,23 +140,25 @@ public class LoginMagicLinkRequestFragment extends Fragment {
 
         final Button fallbackButtonView = view.findViewById(R.id.login_magic_link_fallback_button);
         fallbackButtonView.setVisibility(mFallbackButton == MagicLinkFallbackButton.None ? View.GONE : View.VISIBLE);
-        fallbackButtonView.setText(mFallbackButton == MagicLinkFallbackButton.UsernameAndPassword ?
-                R.string.login_use_wpcom_username_instead :
-                R.string.or_type_your_password);
+        fallbackButtonView.setText(mFallbackButton == MagicLinkFallbackButton.UsernameAndPassword
+                ? R.string.login_use_wpcom_username_instead
+                : R.string.or_type_your_password);
+
         fallbackButtonView.setOnClickListener(v -> {
             switch (mFallbackButton) {
-                case Password -> {
+                case Password:
                     mAnalyticsListener.trackLoginWithPasswordClick();
                     if (mLoginListener != null) {
                         mLoginListener.usePasswordInstead(mEmail);
                     }
-                }
-                case UsernameAndPassword -> {
+                    break;
+                case UsernameAndPassword:
                     if (mLoginListener != null) {
                         mLoginListener.loginViaWpcomUsernameInstead();
                     }
-                }
-                case None -> throw new IllegalStateException("Button should not be visible");
+                    break;
+                case None:
+                    throw new IllegalStateException("Button should not be visible");
             }
         });
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -153,6 +153,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
                     }
                     break;
                 case UsernameAndPassword:
+                    mAnalyticsListener.trackLoginWithWpComUsernamePasswordClick();
                     if (mLoginListener != null) {
                         mLoginListener.loginViaWpcomUsernameInstead();
                     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
@@ -29,24 +29,24 @@ public class LoginMagicLinkSentFragment extends Fragment {
     public static final String TAG = "login_magic_link_sent_fragment_tag";
 
     private static final String ARG_EMAIL_ADDRESS = "ARG_EMAIL_ADDRESS";
-    private static final String ARG_ALLOW_PASSWORD = "ARG_ALLOW_PASSWORD";
+    private static final String ARG_FALLBACK_BUTTON = "ARG_FALLBACK_BUTTON";
 
     private LoginListener mLoginListener;
 
     private String mEmail;
-    private boolean mAllowPassword;
+    private MagicLinkFallbackButton mFallbackButton;
 
     @Inject protected LoginAnalyticsListener mAnalyticsListener;
 
     public static LoginMagicLinkSentFragment newInstance(String email) {
-        return newInstance(email, true);
+        return newInstance(email, MagicLinkFallbackButton.Password);
     }
 
-    public static LoginMagicLinkSentFragment newInstance(String email, boolean allowPassword) {
+    public static LoginMagicLinkSentFragment newInstance(String email, MagicLinkFallbackButton fallbackButton) {
         LoginMagicLinkSentFragment fragment = new LoginMagicLinkSentFragment();
         Bundle args = new Bundle();
         args.putString(ARG_EMAIL_ADDRESS, email);
-        args.putBoolean(ARG_ALLOW_PASSWORD, allowPassword);
+        args.putSerializable(ARG_FALLBACK_BUTTON, fallbackButton);
         fragment.setArguments(args);
         return fragment;
     }
@@ -56,7 +56,7 @@ public class LoginMagicLinkSentFragment extends Fragment {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
             mEmail = getArguments().getString(ARG_EMAIL_ADDRESS);
-            mAllowPassword = getArguments().getBoolean(ARG_ALLOW_PASSWORD);
+            mFallbackButton = (MagicLinkFallbackButton) getArguments().getSerializable(ARG_FALLBACK_BUTTON);
         }
 
         setHasOptionsMenu(true);
@@ -75,15 +75,25 @@ public class LoginMagicLinkSentFragment extends Fragment {
             }
         });
 
-        final Button passwordButton = view.findViewById(R.id.login_enter_password);
-        passwordButton.setVisibility(mAllowPassword ? View.VISIBLE : View.GONE);
-        passwordButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                mAnalyticsListener.trackLoginWithPasswordClick();
-                if (mLoginListener != null) {
-                    mLoginListener.usePasswordInstead(mEmail);
+        final Button fallbackButtonView = view.findViewById(R.id.login_magic_link_fallback_button);
+        fallbackButtonView.setVisibility(mFallbackButton == MagicLinkFallbackButton.None ? View.GONE : View.VISIBLE);
+        fallbackButtonView.setText(mFallbackButton == MagicLinkFallbackButton.UsernameAndPassword ?
+                R.string.login_use_wpcom_username_instead :
+                R.string.or_type_your_password);
+        fallbackButtonView.setOnClickListener(v -> {
+            switch (mFallbackButton) {
+                case Password -> {
+                    mAnalyticsListener.trackLoginWithPasswordClick();
+                    if (mLoginListener != null) {
+                        mLoginListener.usePasswordInstead(mEmail);
+                    }
                 }
+                case UsernameAndPassword -> {
+                    if (mLoginListener != null) {
+                        mLoginListener.loginViaWpcomUsernameInstead();
+                    }
+                }
+                case None -> throw new IllegalStateException("Button should not be visible");
             }
         });
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
@@ -90,6 +90,7 @@ public class LoginMagicLinkSentFragment extends Fragment {
                     }
                     break;
                 case UsernameAndPassword:
+                    mAnalyticsListener.trackLoginWithWpComUsernamePasswordClick();
                     if (mLoginListener != null) {
                         mLoginListener.loginViaWpcomUsernameInstead();
                     }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
@@ -77,23 +77,25 @@ public class LoginMagicLinkSentFragment extends Fragment {
 
         final Button fallbackButtonView = view.findViewById(R.id.login_magic_link_fallback_button);
         fallbackButtonView.setVisibility(mFallbackButton == MagicLinkFallbackButton.None ? View.GONE : View.VISIBLE);
-        fallbackButtonView.setText(mFallbackButton == MagicLinkFallbackButton.UsernameAndPassword ?
-                R.string.login_use_wpcom_username_instead :
-                R.string.or_type_your_password);
+        fallbackButtonView.setText(mFallbackButton == MagicLinkFallbackButton.UsernameAndPassword
+                ? R.string.login_use_wpcom_username_instead
+                : R.string.or_type_your_password);
+
         fallbackButtonView.setOnClickListener(v -> {
             switch (mFallbackButton) {
-                case Password -> {
+                case Password:
                     mAnalyticsListener.trackLoginWithPasswordClick();
                     if (mLoginListener != null) {
                         mLoginListener.usePasswordInstead(mEmail);
                     }
-                }
-                case UsernameAndPassword -> {
+                    break;
+                case UsernameAndPassword:
                     if (mLoginListener != null) {
                         mLoginListener.loginViaWpcomUsernameInstead();
                     }
-                }
-                case None -> throw new IllegalStateException("Button should not be visible");
+                    break;
+                case None:
+                    throw new IllegalStateException("Button should not be visible");
             }
         });
 

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/MagicLinkFallbackButton.kt
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/MagicLinkFallbackButton.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.login
+
+enum class MagicLinkFallbackButton {
+    None,
+    Password,
+    UsernameAndPassword
+}

--- a/WordPressLoginFlow/src/main/res/layout/login_magic_link_request_screen.xml
+++ b/WordPressLoginFlow/src/main/res/layout/login_magic_link_request_screen.xml
@@ -33,7 +33,7 @@
                 android:text="@string/login_magic_links_label" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/login_enter_password"
+                android:id="@+id/login_magic_link_fallback_button"
                 style="@style/Widget.LoginFlow.Button.Tertiary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/WordPressLoginFlow/src/main/res/layout/login_magic_link_sent_screen.xml
+++ b/WordPressLoginFlow/src/main/res/layout/login_magic_link_sent_screen.xml
@@ -40,7 +40,7 @@
                 android:text="@string/magic_link_not_seeing_email_message" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/login_enter_password"
+                android:id="@+id/login_magic_link_fallback_button"
                 style="@style/Widget.LoginFlow.Button.Tertiary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="create_account">Create account</string>
     <string name="or_type_your_password">Or type your password</string>
     <string name="or_use_password">Use password to sign in</string>
+    <string name="login_use_wpcom_username_instead">Use username and password instead</string>
     <string name="username">Username</string>
     <string name="password">Password</string>
     <string name="help">Help</string>


### PR DESCRIPTION
Part of implementing https://github.com/woocommerce/woocommerce-android/issues/13321

This PR the second part of the logic: updating the Magic Link screens to add a button "Use username and password instead" when used in this flow.

For testing, please check https://github.com/woocommerce/woocommerce-android/pull/13345