### PR TITLE
Update dialogs neutral button

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java
@@ -6,6 +6,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.widget.Button;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
@@ -76,12 +77,17 @@ public class LoginSiteAddressHelpDialogFragment extends DialogFragment {
             mAnalyticsListener.trackUrlHelpScreenViewed();
         }
         AlertDialog dialog = alert.create();
+        dialog.setOnShowListener(shownDialog -> setNeutralButton(dialog.getButton(BUTTON_NEUTRAL)));
+
+        return dialog;
+    }
+
+    private void setNeutralButton(@NonNull Button button) {
         Context context = getContext();
         if (context != null) {
             int textColor = context.getColor(R.color.login_dialog_neutral_text_button_color);
-            dialog.setOnShowListener(shownDialog -> dialog.getButton(BUTTON_NEUTRAL).setTextColor(textColor));
+            button.setTextColor(textColor);
+            button.setAllCaps(false);
         }
-
-        return dialog;
     }
 }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.login;
 
+import static android.content.DialogInterface.BUTTON_NEUTRAL;
+
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -39,7 +41,8 @@ public class LoginSiteAddressHelpDialogFragment extends DialogFragment {
         }
     }
 
-    @Override public void onDetach() {
+    @Override
+    public void onDetach() {
         super.onDetach();
         mLoginListener = null;
     }
@@ -72,7 +75,13 @@ public class LoginSiteAddressHelpDialogFragment extends DialogFragment {
         if (savedInstanceState == null) {
             mAnalyticsListener.trackUrlHelpScreenViewed();
         }
+        AlertDialog dialog = alert.create();
+        Context context = getContext();
+        if (context != null) {
+            int textColor = context.getColor(R.color.login_dialog_neutral_text_button_color);
+            dialog.setOnShowListener(shownDialog -> dialog.getButton(BUTTON_NEUTRAL).setTextColor(textColor));
+        }
 
-        return alert.create();
+        return dialog;
     }
 }

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java
@@ -4,7 +4,6 @@ import static android.content.DialogInterface.BUTTON_NEUTRAL;
 
 import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.os.Bundle;
 import android.widget.Button;
 
@@ -38,7 +37,7 @@ public class LoginSiteAddressHelpDialogFragment extends DialogFragment {
         if (context instanceof LoginListener) {
             mLoginListener = (LoginListener) context;
         } else {
-            throw new RuntimeException(context.toString() + " must implement LoginListener");
+            throw new RuntimeException(context + " must implement LoginListener");
         }
     }
 
@@ -60,18 +59,14 @@ public class LoginSiteAddressHelpDialogFragment extends DialogFragment {
 
         //noinspection InflateParams
         alert.setView(getActivity().getLayoutInflater().inflate(R.layout.login_alert_site_address_help, null));
-        alert.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int whichButton) {
-                mAnalyticsListener.trackDismissDialog();
-                dialog.dismiss();
-            }
+        alert.setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
+            mAnalyticsListener.trackDismissDialog();
+            dialog.dismiss();
         });
-        alert.setNeutralButton(R.string.login_site_address_more_help, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                mLoginListener.helpFindingSiteAddress(mAccountStore.getAccount().getUserName(), mSiteStore);
-            }
-        });
+        alert.setNeutralButton(R.string.login_site_address_more_help,
+                (dialog, which) -> mLoginListener.helpFindingSiteAddress(
+                        mAccountStore.getAccount().getUserName(),
+                        mSiteStore));
 
         if (savedInstanceState == null) {
             mAnalyticsListener.trackUrlHelpScreenViewed();

--- a/WordPressLoginFlow/src/main/res/values-night/colors.xml
+++ b/WordPressLoginFlow/src/main/res/values-night/colors.xml
@@ -3,4 +3,7 @@
     <!-- Temporarily using a hardcoded color for the avatar placeholder in order
     to avoid having to handle tint programmatically in more than one place -->
     <color name="avatar_placeholder">#61FFFFFF</color>
+
+    <!-- Login -->
+    <color name="login_dialog_neutral_text_button_color">@color/material_white_50</color>
 </resources>

--- a/WordPressLoginFlow/src/main/res/values/colors.xml
+++ b/WordPressLoginFlow/src/main/res/values/colors.xml
@@ -24,4 +24,5 @@
     <!-- Login -->
     <color name="login_secondary_button_icon_tint_color">#c8d7e1</color>
     <color name="login_notification_accent_color">#0087be</color>
+    <color name="login_dialog_neutral_text_button_color">@color/wp_blue_50</color>
 </resources>


### PR DESCRIPTION
This updates the neutral button of dialog in the login flow:
- Updates neutral button color to colorPrimary in light and to white in dark mode. Consumer apps can override `login_dialog_neutral_text_button_color` and update this color.
- Disables all caps for the button.

> [!WARNING]  
> Don't merge before Jan 24. I'll handle merging.

This can be tested in woocommerce/woocommerce-android#13377